### PR TITLE
add common permission view

### DIFF
--- a/adhocracy4/contrib/views.py
+++ b/adhocracy4/contrib/views.py
@@ -1,0 +1,20 @@
+from rules.contrib.views import PermissionRequiredMixin \
+    as RulesPermissionRequiredMixin
+
+"""
+Common views.
+
+"""
+
+
+class PermissionRequiredMixin(RulesPermissionRequiredMixin):
+
+    @property
+    def raise_exception(self):
+        """
+        Raises authentication error instead of redirecting to login.
+
+        Needed, as permissions for a logged-in user might still be
+        limited by the current phase.
+        """
+        return self.request.user.is_authenticated()


### PR DESCRIPTION
Permission view that does not redirect to login on authentication failure.

Needed, as the permissions for logged in users might be limited by the current phase. A redirect to login leads to redirect loop in such a case.