### PR TITLE
Fix comments config spelling (breaking)

### DIFF
--- a/adhocracy4/comments/apps.py
+++ b/adhocracy4/comments/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 
 
-class CommentConfig(AppConfig):
+class CommentsConfig(AppConfig):
     name = 'adhocracy4.comments'
     label = 'a4comments'
 


### PR DESCRIPTION
Use plural as in other configs