### PR TITLE
comment markup improvements

### DIFF
--- a/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
+++ b/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
@@ -12,15 +12,15 @@ const CommentManageDropdown = (props) => {
         <ul className="dropdown-menu">
           {props.renderModeratorOptions && [
             <li key="1">
-              <button onClick={props.toggleEdit} aria-hidden="true">{django.gettext('Edit')}</button>
+              <button onClick={props.toggleEdit}>{django.gettext('Edit')}</button>
             </li>,
             <li className="divider" key="2" />,
             <li key="3"><a href={`#comment_delete_${props.id}`} data-toggle="modal"
-              aria-hidden="true">{django.gettext('Delete')}</a></li>,
+              >{django.gettext('Delete')}</a></li>,
             <li className="divider" key="4" />
           ]}
           <li><a href={`#report_comment_${props.id}`} data-toggle="modal"
-            aria-hidden="true">{django.gettext('Report')}</a>
+            >{django.gettext('Report')}</a>
           </li>
         </ul>
       </li>

--- a/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
+++ b/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
@@ -12,14 +12,14 @@ const CommentManageDropdown = (props) => {
         <ul className="dropdown-menu">
           {props.renderModeratorOptions && [
             <li key="1">
-              <button type="button" onClick={props.toggleEdit}>{django.gettext('Edit')}</button>
+              <button type="button" className="dropdown-item" onClick={props.toggleEdit}>{django.gettext('Edit')}</button>
             </li>,
             <li className="divider" key="2" />,
-            <li key="3"><a href={`#comment_delete_${props.id}`} data-toggle="modal"
+            <li key="3"><a className="dropdown-item" href={`#comment_delete_${props.id}`} data-toggle="modal"
               >{django.gettext('Delete')}</a></li>,
             <li className="divider" key="4" />
           ]}
-          <li><a href={`#report_comment_${props.id}`} data-toggle="modal"
+          <li><a className="dropdown-item" href={`#report_comment_${props.id}`} data-toggle="modal"
             >{django.gettext('Report')}</a>
           </li>
         </ul>

--- a/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
+++ b/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
@@ -5,14 +5,14 @@ const CommentManageDropdown = (props) => {
   return (
     <ul className="nav navbar-nav">
       <li className="dropdown">
-        <button className="dropdown-toggle" aria-haspopup="true" aria-expanded="false"
-          data-toggle="dropdown">
+        <button type="button" className="dropdown-toggle" aria-haspopup="true"
+          aria-expanded="false" data-toggle="dropdown">
           <i class="fa fa-ellipsis-h" aria-hidden="true"></i>
         </button>
         <ul className="dropdown-menu">
           {props.renderModeratorOptions && [
             <li key="1">
-              <button onClick={props.toggleEdit}>{django.gettext('Edit')}</button>
+              <button type="button" onClick={props.toggleEdit}>{django.gettext('Edit')}</button>
             </li>,
             <li className="divider" key="2" />,
             <li key="3"><a href={`#comment_delete_${props.id}`} data-toggle="modal"

--- a/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
+++ b/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
@@ -12,14 +12,14 @@ const CommentManageDropdown = (props) => {
         <ul className="dropdown-menu">
           {props.renderModeratorOptions && [
             <li key="1">
-              <button type="button" className="dropdown-item" onClick={props.toggleEdit}>{django.gettext('Edit')}</button>
+              <button type="button" onClick={props.toggleEdit}>{django.gettext('Edit')}</button>
             </li>,
             <li className="divider" key="2" />,
-            <li key="3"><a className="dropdown-item" href={`#comment_delete_${props.id}`} data-toggle="modal"
+            <li key="3"><a href={`#comment_delete_${props.id}`} data-toggle="modal"
               >{django.gettext('Delete')}</a></li>,
             <li className="divider" key="4" />
           ]}
-          <li><a className="dropdown-item" href={`#report_comment_${props.id}`} data-toggle="modal"
+          <li><a href={`#report_comment_${props.id}`} data-toggle="modal"
             >{django.gettext('Report')}</a>
           </li>
         </ul>

--- a/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
+++ b/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
@@ -5,12 +5,13 @@ const CommentManageDropdown = (props) => {
   return (
     <ul className="nav navbar-nav">
       <li className="dropdown">
-        <a href="#" className="dropdown-toggle icon fa-ellipsis-h" role="button"
-          aria-haspopup="true" aria-hidden="true" aria-expanded="false" data-toggle="dropdown" />
+        <button className="dropdown-toggle icon fa-ellipsis-h"
+          aria-haspopup="true" aria-hidden="true" aria-expanded="false" data-toggle="dropdown">
+        </button>
         <ul className="dropdown-menu">
           {props.renderModeratorOptions && [
             <li key="1">
-              <a href="#" onClick={props.toggleEdit} aria-hidden="true">{django.gettext('Edit')}</a>
+              <button onClick={props.toggleEdit} aria-hidden="true">{django.gettext('Edit')}</button>
             </li>,
             <li className="divider" key="2" />,
             <li key="3"><a href={`#comment_delete_${props.id}`} data-toggle="modal"

--- a/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
+++ b/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
@@ -5,8 +5,9 @@ const CommentManageDropdown = (props) => {
   return (
     <ul className="nav navbar-nav">
       <li className="dropdown">
-        <button className="dropdown-toggle icon fa-ellipsis-h"
-          aria-haspopup="true" aria-hidden="true" aria-expanded="false" data-toggle="dropdown">
+        <button className="dropdown-toggle" aria-haspopup="true" aria-expanded="false"
+          data-toggle="dropdown">
+          <i class="fa fa-ellipsis-h" aria-hidden="true"></i>
         </button>
         <ul className="dropdown-menu">
           {props.renderModeratorOptions && [

--- a/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
+++ b/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
@@ -7,7 +7,7 @@ const CommentManageDropdown = (props) => {
       <li className="dropdown">
         <button type="button" className="dropdown-toggle" aria-haspopup="true"
           aria-expanded="false" data-toggle="dropdown">
-          <i class="fa fa-ellipsis-h" aria-hidden="true"></i>
+          <i className="fa fa-ellipsis-h" aria-hidden="true"></i>
         </button>
         <ul className="dropdown-menu">
           {props.renderModeratorOptions && [

--- a/adhocracy4/comments/static/comments/CommentReplyBar.jsx
+++ b/adhocracy4/comments/static/comments/CommentReplyBar.jsx
@@ -11,14 +11,16 @@ const CommentReplyBar = (props) => {
   let childCommentCount
   if (props.childCommentsLength > 0) {
     childCommentCount = (
-      <button type="button" onClick={props.showComments}>{pluralizeString(props.childCommentsLength)}</button>
+      <button className="comment-reply-button" type="button" onClick={props.showComments}>
+        {pluralizeString(props.childCommentsLength)}
+      </button>
     )
   }
 
   let replyButton
   if (props.allowForm) {
     replyButton = (
-      <button type="button" onClick={props.showComments}>
+      <button className="comment-reply-button" type="button" onClick={props.showComments}>
         <i className="fa fa-reply" aria-hidden="true"></i>
         {django.gettext('Answer')}
       </button>

--- a/adhocracy4/comments/static/comments/CommentReplyBar.jsx
+++ b/adhocracy4/comments/static/comments/CommentReplyBar.jsx
@@ -11,34 +11,28 @@ const CommentReplyBar = (props) => {
   let childCommentCount
   if (props.childCommentsLength > 0) {
     childCommentCount = (
-      <ul className="nav navbar-nav">
-        <li className="entry">
-          <button type="button" onClick={props.showComments}>{pluralizeString(props.childCommentsLength)}</button>
-        </li>
-      </ul>
+      <button type="button" onClick={props.showComments}>{pluralizeString(props.childCommentsLength)}</button>
     )
   }
 
   let replyButton
   if (props.allowForm) {
     replyButton = (
-      <ul className="nav navbar-nav navbar-right">
-        <li className="entry">
-          <button type="button" onClick={props.showComments}>
-            <i className="fa fa-reply" aria-hidden="true"></i>
-            {django.gettext('Answer')}
-          </button>
-        </li>
-      </ul>
+      <button type="button" onClick={props.showComments}>
+        <i className="fa fa-reply" aria-hidden="true"></i>
+        {django.gettext('Answer')}
+      </button>
     )
   }
   if (replyButton || childCommentCount) {
     return (
       <div className="action-bar">
-        <nav className="navbar navbar-default navbar-static">
+        <div className="navbar">
           {childCommentCount}
-          {replyButton}
-        </nav>
+          <div className="navbar-right">
+            {replyButton}
+          </div>
+        </div>
       </div>
     )
   } else {

--- a/adhocracy4/comments/static/comments/CommentReplyBar.jsx
+++ b/adhocracy4/comments/static/comments/CommentReplyBar.jsx
@@ -24,7 +24,8 @@ const CommentReplyBar = (props) => {
     replyButton = (
       <ul className="nav navbar-nav navbar-right">
         <li className="entry">
-          <button className="icon fa-reply" onClick={props.showComments} aria-hidden="true">
+          <button onClick={props.showComments}>
+            <i className="fa fa-reply" aria-hidden="true"></i>
             {django.gettext('Answer')}
           </button>
         </li>

--- a/adhocracy4/comments/static/comments/CommentReplyBar.jsx
+++ b/adhocracy4/comments/static/comments/CommentReplyBar.jsx
@@ -13,7 +13,7 @@ const CommentReplyBar = (props) => {
     childCommentCount = (
       <ul className="nav navbar-nav">
         <li className="entry">
-          <a href="#" onClick={props.showComments}>{pluralizeString(props.childCommentsLength)}</a>
+          <button onClick={props.showComments}>{pluralizeString(props.childCommentsLength)}</button>
         </li>
       </ul>
     )
@@ -24,9 +24,9 @@ const CommentReplyBar = (props) => {
     replyButton = (
       <ul className="nav navbar-nav navbar-right">
         <li className="entry">
-          <a href="#" className="icon fa-reply" onClick={props.showComments} aria-hidden="true">
+          <button className="icon fa-reply" onClick={props.showComments} aria-hidden="true">
             {django.gettext('Answer')}
-          </a>
+          </button>
         </li>
       </ul>
     )

--- a/adhocracy4/comments/static/comments/CommentReplyBar.jsx
+++ b/adhocracy4/comments/static/comments/CommentReplyBar.jsx
@@ -13,7 +13,7 @@ const CommentReplyBar = (props) => {
     childCommentCount = (
       <ul className="nav navbar-nav">
         <li className="entry">
-          <button onClick={props.showComments}>{pluralizeString(props.childCommentsLength)}</button>
+          <button type="button" onClick={props.showComments}>{pluralizeString(props.childCommentsLength)}</button>
         </li>
       </ul>
     )
@@ -24,7 +24,7 @@ const CommentReplyBar = (props) => {
     replyButton = (
       <ul className="nav navbar-nav navbar-right">
         <li className="entry">
-          <button onClick={props.showComments}>
+          <button type="button" onClick={props.showComments}>
             <i className="fa fa-reply" aria-hidden="true"></i>
             {django.gettext('Answer')}
           </button>


### PR DESCRIPTION
While trying to style the a4 comments for meinberlin I found some issues with the markup:

- `<a href="#">` was used instead of `<button>`
- `class="icon fa-*"` was used instead of a `<i class="fa fa-*">` child (see [CSS in euth_wagtail](https://github.com/liqd/euth_wagtail/blob/40dd0be976073e92ca97a9041abcdc5c6a8c2350/euth_wagtail/assets/scss/components/_comments.scss#L73))
- `aria-hidden="true"` was used for essential elements

