### PR TITLE
add generic sort view

### DIFF
--- a/adhocracy4/contrib/apps.py
+++ b/adhocracy4/contrib/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class OrganisationsConfig(AppConfig):
+class ContribConfig(AppConfig):
     name = 'adhocracy4.contrib'
     label = 'a4contrib'

--- a/adhocracy4/contrib/apps.py
+++ b/adhocracy4/contrib/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class OrganisationsConfig(AppConfig):
+    name = 'adhocracy4.contrib'
+    label = 'a4contrib'

--- a/adhocracy4/contrib/views.py
+++ b/adhocracy4/contrib/views.py
@@ -24,7 +24,7 @@ class SortableListView(generic.ListView):
     """Add sorting via request parameter.
 
     Fields:
-        ordering: List containing the signle default ordering string
+        ordering: List containing the single default ordering string
         orderings_supported: List of possible ordering tuples (ordering,
             ordering name)
     """

--- a/adhocracy4/contrib/views.py
+++ b/adhocracy4/contrib/views.py
@@ -1,3 +1,4 @@
+from django.views import generic
 from rules.contrib.views import PermissionRequiredMixin \
     as RulesPermissionRequiredMixin
 
@@ -18,3 +19,20 @@ class PermissionRequiredMixin(RulesPermissionRequiredMixin):
         limited by the current phase.
         """
         return self.request.user.is_authenticated()
+
+
+class SortableListView(generic.ListView):
+    """
+    ordering_current: List of possible ordering tuples (ordering,
+        ordering name).
+    """
+    orderings_supported = []
+
+    def get_ordering(self):
+        ordering = self.request.GET.get('ordering')
+        if ordering and ordering in dict(self.orderings_supported):
+            self.ordering = [ordering]
+        return self.ordering
+
+    def get_current_ordering_name(self):
+        return dict(self.orderings_supported)[self.ordering[0]]

--- a/adhocracy4/contrib/views.py
+++ b/adhocracy4/contrib/views.py
@@ -12,8 +12,7 @@ class PermissionRequiredMixin(RulesPermissionRequiredMixin):
 
     @property
     def raise_exception(self):
-        """
-        Raises authentication error instead of redirecting to login.
+        """Raise authentication error instead of redirecting to login.
 
         Needed, as permissions for a logged-in user might still be
         limited by the current phase.
@@ -22,17 +21,22 @@ class PermissionRequiredMixin(RulesPermissionRequiredMixin):
 
 
 class SortableListView(generic.ListView):
+    """Add sorting via request parameter.
+
+    Fields:
+        ordering: List containing the signle default ordering string
+        orderings_supported: List of possible ordering tuples (ordering,
+            ordering name)
     """
-    ordering_current: List of possible ordering tuples (ordering,
-        ordering name).
-    """
+
+    ordering = []
     orderings_supported = []
 
-    def get_ordering(self):
+    def dispatch(self, *args, **kwargs):
         ordering = self.request.GET.get('ordering')
         if ordering and ordering in dict(self.orderings_supported):
             self.ordering = [ordering]
-        return self.ordering
+        return super().dispatch(*args, **kwargs)
 
     def get_current_ordering_name(self):
         return dict(self.orderings_supported)[self.ordering[0]]

--- a/tests/apps/questions/views.py
+++ b/tests/apps/questions/views.py
@@ -1,7 +1,11 @@
-from django.views.generic import list
-
+from adhocracy4.contrib.views import SortableListView
 from . import models
 
 
-class QuestionList(list.ListView):
+class QuestionList(SortableListView):
     model = models.Question
+    ordering = ['-created']
+    orderings_supported = [
+        ('-created', 'Most recent'),
+        ('text', 'Alphabetical'),
+    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from django import test
 from pytest_factoryboy import register
 from rest_framework.test import APIClient
 
@@ -15,6 +16,11 @@ def apiclient():
 @pytest.fixture
 def image_factory():
     return img_factories.ImageFactory()
+
+
+@pytest.fixture
+def request_factory():
+    return test.RequestFactory()
 
 
 register(factories.UserFactory)

--- a/tests/contrib/test_views.py
+++ b/tests/contrib/test_views.py
@@ -1,0 +1,35 @@
+import pytest
+
+from tests.apps.questions.views import QuestionList
+
+
+@pytest.mark.django_db
+def test_sort_view_ordering_default(request_factory):
+    request = request_factory.get(path='/')
+    sort_view = QuestionList(request=request)
+    sort_view.dispatch(request)
+    assert sort_view.ordering == ['-created']
+
+
+@pytest.mark.django_db
+def test_sort_view_ordering_valid(request_factory):
+    request = request_factory.get(path='/?ordering=text')
+    sort_view = QuestionList(request=request)
+    sort_view.dispatch(request)
+    assert sort_view.ordering == ['text']
+
+
+@pytest.mark.django_db
+def test_sort_view_ordering_invalid(request_factory):
+    request = request_factory.get(path='/?ordering=invalid')
+    sort_view = QuestionList(request=request)
+    sort_view.dispatch(request)
+    assert sort_view.ordering == ['-created']
+
+
+@pytest.mark.django_db
+def test_sort_view_ordering_name(request_factory):
+    request = request_factory.get(path='/')
+    sort_view = QuestionList(request=request)
+    sort_view.dispatch(request)
+    assert sort_view.get_current_ordering_name() == 'Most recent'


### PR DESCRIPTION
Extends the ordering functionality of the Django `generic.ListView`:

- Applies sort from the request parameter
- Adds supported orderings dict list
- Provides function get the ordering name