### PR TITLE
Do not set moment locale in comment code

### DIFF
--- a/adhocracy4/comments/static/comments/Comment.jsx
+++ b/adhocracy4/comments/static/comments/Comment.jsx
@@ -10,8 +10,6 @@ var React = require('react')
 var django = require('django')
 var moment = require('moment')
 
-moment.locale(django.languageCode)
-
 var safeHtml = function (text) {
   return { __html: text }
 }

--- a/adhocracy4/comments/static/comments/CommentBox.jsx
+++ b/adhocracy4/comments/static/comments/CommentBox.jsx
@@ -62,16 +62,12 @@ let CommentBox = React.createClass({
       comments: this.props.comments
     }
   },
-  componentDidMount: function () {
-    moment.locale(this.props.language)
-  },
   getChildContext: function () {
     return {
       isAuthenticated: this.props.isAuthenticated,
       isModerator: this.props.isModerator,
       comments_contenttype: this.props.comments_contenttype,
-      user_name: this.props.user_name,
-      language: this.props.language
+      user_name: this.props.user_name
     }
   },
   render: function () {
@@ -98,7 +94,6 @@ CommentBox.childContextTypes = {
   isModerator: React.PropTypes.bool,
   comments_contenttype: React.PropTypes.number,
   user_name: React.PropTypes.string,
-  language: React.PropTypes.string
 }
 
 module.exports = CommentBox

--- a/adhocracy4/comments/templatetags/react_comments.py
+++ b/adhocracy4/comments/templatetags/react_comments.py
@@ -32,8 +32,6 @@ def react_comments(context, obj):
     comments_contenttype = ContentType.objects.get_for_model(Comment)
     pk = obj.pk
 
-    language = utils.translation.get_language()
-
     mountpoint = 'comments_for_{contenttype}_{pk}'.format(
         contenttype=contenttype.pk,
         pk=pk
@@ -46,7 +44,6 @@ def react_comments(context, obj):
         'isAuthenticated': is_authenticated,
         'isModerator': is_moderator,
         'user_name': user_name,
-        'language': language,
         'isReadOnly': not has_comment_permission,
     }
 

--- a/tests/comments/test_templatetags.py
+++ b/tests/comments/test_templatetags.py
@@ -51,7 +51,6 @@ def test_react_rating_anonymous(rf, question, comment):
         'isAuthenticated': False,
         'isModerator': False,
         'isReadOnly': True,
-        'language': 'en-us',
         'user_name': '',
     }
 
@@ -73,6 +72,5 @@ def test_react_rating_user(rf, user, question, comment):
         'isAuthenticated': True,
         'isModerator': False,
         'isReadOnly': False,
-        'language': 'en-us',
         'user_name': user.username,
     }


### PR DESCRIPTION
The locale is a global setting and should not be set in a component.  Instead, we should call `moment.locale(django.languageCode)` in one central place (in the platform code).

The current version has the concrete issue that the locale is set to two different values: First to `django.languageCode` and then to `utils.translation.get_language()` on the first interaction.