### PR TITLE
Send emails one by one to each receiver

### DIFF
--- a/adhocracy4/emails/email.py
+++ b/adhocracy4/emails/email.py
@@ -69,12 +69,15 @@ class Email:
         html = select_template([
             'emails/{}.{}.html'.format(template, lang) for lang in languages
         ])
-        mail = EmailMultiAlternatives(
-            subject=subject.render(context).strip(),
-            body=plaintext.render(context),
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            to=receivers,
-        )
+
+        for receiver in receivers:
+            mail = EmailMultiAlternatives(
+                subject=subject.render(context).strip(),
+                body=plaintext.render(context),
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                to=[receiver],
+            )
+
         if len(attachments) > 0:
             mail.mixed_subtype = 'related'
 


### PR DESCRIPTION
As I see it the behaviour of sending mails with multiple to entries is never wanted on a a platform. So I think we should change how sending email works.