### PR TITLE
remove text input in image upload from tab order

### DIFF
--- a/adhocracy4/images/widgets.py
+++ b/adhocracy4/images/widgets.py
@@ -39,7 +39,8 @@ class ImageInputWidget(widgets.ClearableFileInput):
 
         text_input = widgets.TextInput().render('__noname__', file_name, {
             'class': 'form-control form-control-file-dummy',
-            'placeholder': file_placeholder
+            'placeholder': file_placeholder,
+            'tabindex': '-1'
         })
 
         checkbox_id = self.clear_checkbox_id(name)


### PR DESCRIPTION
As far as I understand the text input in the image yupload widget is only there for its visual appearance. It should therefore be excluded from the tab order.