### PR TITLE
resolve project migration conflict

### DIFF
--- a/adhocracy4/projects/migrations/0005_auto_20170313_1407.py
+++ b/adhocracy4/projects/migrations/0005_auto_20170313_1407.py
@@ -7,12 +7,17 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('a4projects', '0003_auto_20170130_0836'),
+        ('a4projects', '0004_project_is_archived'),
     ]
 
     operations = [
         migrations.AlterModelOptions(
             name='project',
             options={'ordering': ['-created']},
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='is_archived',
+            field=models.BooleanField(verbose_name='Project is archived', default=False, help_text='Set to archive the project'),
         ),
     ]


### PR DESCRIPTION
Two 004 migrations were created in parallel. Recreating the ordering migration.