### PR TITLE
Module feature detection

### DIFF
--- a/adhocracy4/modules/models.py
+++ b/adhocracy4/modules/models.py
@@ -24,6 +24,12 @@ class Module(models.Model):
             if hasattr(self, setting):
                 return getattr(self, setting)
 
+    def has_feature(self, feature, model):
+        for phase in self.phase_set.all():
+            if phase.has_feature(feature, model):
+                return True
+        return False
+
 
 class Item(base.UserGeneratedContentModel):
     module = models.ForeignKey(Module, on_delete=models.CASCADE)

--- a/adhocracy4/modules/templatetags/module_tags.py
+++ b/adhocracy4/modules/templatetags/module_tags.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+
+@register.assignment_tag
+def itemHasFeature(item, feature):
+    return item.module.has_feature(feature, item.__class__)

--- a/adhocracy4/modules/templatetags/module_tags.py
+++ b/adhocracy4/modules/templatetags/module_tags.py
@@ -3,6 +3,6 @@ from django import template
 register = template.Library()
 
 
-@register.assignment_tag
-def itemHasFeature(item, feature):
+@register.filter
+def has_feature(item, feature):
     return item.module.has_feature(feature, item.__class__)

--- a/tests/modules/test_module_models.py
+++ b/tests/modules/test_module_models.py
@@ -1,0 +1,9 @@
+import pytest
+
+from tests.apps.questions import models as q_models
+
+
+@pytest.mark.django_db
+def test_has_feature(phase):
+    module = phase.module
+    assert module.has_feature('crud', q_models.Question)

--- a/tests/modules/test_module_templatetags.py
+++ b/tests/modules/test_module_templatetags.py
@@ -7,5 +7,5 @@ from adhocracy4.test.helpers import render_template
 def test_get_class_running_out(question, phase):
     question.module = phase.module
     template = '{% load module_tags %}' \
-               '{% itemHasFeature item "crud" as x %}{{x}}'
+               '{% if item|has_feature:"crud" %}True{% endif %}'
     assert 'True' == render_template(template, {'item': question})

--- a/tests/modules/test_module_templatetags.py
+++ b/tests/modules/test_module_templatetags.py
@@ -1,0 +1,11 @@
+import pytest
+
+from adhocracy4.test.helpers import render_template
+
+
+@pytest.mark.django_db
+def test_get_class_running_out(question, phase):
+    question.module = phase.module
+    template = '{% load module_tags %}' \
+               '{% itemHasFeature item "crud" as x %}{{x}}'
+    assert 'True' == render_template(template, {'item': question})


### PR DESCRIPTION
Add a helper function to check if any phase of a module provides a certain feature.

Add a templatetag to check if the module of an item has a feature in its phases. Using item instead of module here, as it directly provides the module and the item class.