### PR TITLE
APIs for generic foreign keys

### DIFF
--- a/adhocracy4/api/mixins.py
+++ b/adhocracy4/api/mixins.py
@@ -1,0 +1,47 @@
+from django.contrib.contenttypes.models import ContentType
+from django.http import Http404
+from django.shortcuts import get_object_or_404
+
+
+class ContentTypeMixin:
+    """
+    Should be used in combination with ContentTypeRouter to fetch the
+    decode content_type and object_pk of an request.
+
+    Currently only numeric object_pk are supported.
+    """
+    content_type_filter = []
+
+    def dispatch(self, request, *args, **kwargs):
+        content_type = kwargs.get('content_type', '')
+        object_pk = kwargs.get('object_pk', '')
+
+        if not content_type.isdigit() or not object_pk.isdigit():
+            raise Http404
+        else:
+            self.content_type_id = int(content_type)
+            self.object_pk = int(object_pk)
+
+        current_ct_strs = (
+            self.content_type.app_label,
+            self.content_type.model,
+        )
+
+        if current_ct_strs not in self.content_type_filter:
+            raise Http404
+
+        return super().dispatch(request, *args, **kwargs)
+
+    @property
+    def content_type(self):
+        try:
+            return ContentType.objects.get_for_id(self.content_type_id)
+        except ContentType.DoesNotExist:
+            raise Http404
+
+    @property
+    def content_object(self):
+        return get_object_or_404(
+            self.content_type.model_class(),
+            pk=self.object_pk
+        )

--- a/adhocracy4/api/routers.py
+++ b/adhocracy4/api/routers.py
@@ -1,0 +1,24 @@
+from rest_framework import routers
+
+
+class ContentTypeRouterMixin():
+
+    prefix_regex = (
+        'contenttypes/(?P<content_type>[\d]+)/'
+        'objects/(?P<object_pk>[\d]+)/{prefix}'
+    )
+
+    @property
+    def routes(self):
+        routes = super().routes
+        return [route._replace(url=route.url.replace('{prefix}',
+                                                     self.prefix_regex))
+                for route in routes]
+
+
+class ContentTypeSimpleRouter(ContentTypeRouterMixin, routers.SimpleRouter):
+    pass
+
+
+class ContentTypeDefaultRouter(ContentTypeRouterMixin, routers.DefaultRouter):
+    pass

--- a/adhocracy4/comments/api.py
+++ b/adhocracy4/comments/api.py
@@ -1,6 +1,9 @@
+from django.conf import settings
+
 from rest_framework import filters, mixins, permissions, viewsets
 from rest_framework.response import Response
 
+from adhocracy4.api.mixins import ContentTypeMixin
 from adhocracy4.api.permissions import IsCreatorOrReadOnly
 
 from .models import Comment
@@ -11,6 +14,7 @@ class CommentViewSet(mixins.CreateModelMixin,
                      mixins.RetrieveModelMixin,
                      mixins.UpdateModelMixin,
                      mixins.DestroyModelMixin,
+                     ContentTypeMixin,
                      viewsets.GenericViewSet):
 
     queryset = Comment.objects.all().order_by('-created')
@@ -19,9 +23,13 @@ class CommentViewSet(mixins.CreateModelMixin,
         permissions.IsAuthenticatedOrReadOnly, IsCreatorOrReadOnly)
     filter_backends = (filters.DjangoFilterBackend,)
     filter_fields = ('object_pk', 'content_type')
+    content_type_filter = settings.A4_COMMENTABLES
 
     def perform_create(self, serializer):
-        serializer.save(creator=self.request.user)
+        serializer.save(
+            content_object=self.content_object,
+            creator=self.request.user
+        )
 
     def destroy(self, request, *args, **kwargs):
         comment = self.get_object()

--- a/adhocracy4/comments/serializers.py
+++ b/adhocracy4/comments/serializers.py
@@ -13,7 +13,8 @@ class CommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comment
         read_only_fields = ('modified', 'created', 'id',
-                            'user_name', 'ratings')
+                            'user_name', 'ratings', 'content_type',
+                            'object_pk')
         exclude = ('creator', 'is_censored', 'is_removed')
 
     def get_user_name(self, obj):

--- a/adhocracy4/comments/static/comments/Comment.jsx
+++ b/adhocracy4/comments/static/comments/Comment.jsx
@@ -66,11 +66,13 @@ var Comment = React.createClass({
     if (this.state.edit) {
       comment = (
         <CommentEditForm
+          subjectType={this.props.content_type}
+          subjectId={this.props.object_pk}
           comment={this.props.children}
           rows="5"
           handleCancel={this.toggleEdit}
           onCommentSubmit={newComment => {
-            this.props.handleCommentModify(newComment.comment, this.props.index, this.props.parentIndex)
+            this.props.handleCommentModify(newComment, this.props.index, this.props.parentIndex)
             this.state.edit = false
           }}
         />

--- a/adhocracy4/comments/static/comments/CommentBox.jsx
+++ b/adhocracy4/comments/static/comments/CommentBox.jsx
@@ -35,16 +35,14 @@ let CommentBox = React.createClass({
         })
       }.bind(this))
   },
-  handleCommentModify: function (commentText, index, parentIndex) {
+  handleCommentModify: function (modifiedComment, index, parentIndex) {
     var comments = this.state.comments
     var comment = comments[index]
     if (typeof parentIndex !== 'undefined') {
       comment = comments[parentIndex].child_comments[index]
     }
 
-    api.comments.change({
-      comment: commentText, id: comment.id
-    }, comment.id)
+    api.comments.change(modifiedComment, comment.id)
       .done(this.updateStateComment.bind(this, index, parentIndex))
   },
   handleCommentDelete: function (index, parentIndex) {
@@ -54,7 +52,11 @@ let CommentBox = React.createClass({
       comment = comments[parentIndex].child_comments[index]
     }
 
-    api.comments.delete(comment.id)
+    var data = {
+      content_type: comment.content_type,
+      object_pk: comment.object_pk
+    }
+    api.comments.delete(data, comment.id)
       .done(this.updateStateComment.bind(this, index, parentIndex))
   },
   getInitialState: function () {

--- a/adhocracy4/comments/static/comments/CommentEditForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentEditForm.jsx
@@ -15,7 +15,9 @@ var CommentEditForm = React.createClass({
       return
     }
     this.props.onCommentSubmit({
-      comment: comment
+      comment: comment,
+      object_pk: this.props.subjectId,
+      content_type: this.props.subjectType
     })
   },
   render: function () {

--- a/adhocracy4/comments/static/comments/CommentList.jsx
+++ b/adhocracy4/comments/static/comments/CommentList.jsx
@@ -17,6 +17,7 @@ var CommentList = React.createClass({
               authorIsModerator={comment.is_moderator}
               id={comment.id}
               content_type={comment.content_type}
+              object_pk={comment.object_pk}
               is_deleted={comment.is_deleted}
               index={index}
               parentIndex={this.props.parentIndex}

--- a/adhocracy4/ratings/api.py
+++ b/adhocracy4/ratings/api.py
@@ -29,7 +29,7 @@ class RatingViewSet(mixins.CreateModelMixin,
             creator=self.request.user
         )
 
-    def destroy(self, request, pk=None):
+    def destroy(self, request, content_type, object_pk, pk=None):
         """
         Sets value to zero
         NOTE: Rating is NOT deleted.

--- a/adhocracy4/ratings/api.py
+++ b/adhocracy4/ratings/api.py
@@ -1,6 +1,9 @@
+from django.conf import settings
+
 from rest_framework import filters, mixins, permissions, viewsets
 from rest_framework.response import Response
 
+from adhocracy4.api.mixins import ContentTypeMixin
 from adhocracy4.api.permissions import IsCreatorOrReadOnly
 
 from .models import Rating
@@ -9,6 +12,7 @@ from .serializers import RatingSerializer
 
 class RatingViewSet(mixins.CreateModelMixin,
                     mixins.UpdateModelMixin,
+                    ContentTypeMixin,
                     viewsets.GenericViewSet):
 
     queryset = Rating.objects.all()
@@ -17,9 +21,13 @@ class RatingViewSet(mixins.CreateModelMixin,
         permissions.IsAuthenticatedOrReadOnly, IsCreatorOrReadOnly)
     filter_backends = (filters.DjangoFilterBackend,)
     filter_fields = ('object_pk', 'content_type')
+    content_type_filter = settings.A4_RATEABLES
 
     def perform_create(self, serializer):
-        serializer.save(creator=self.request.user)
+        serializer.save(
+            content_object=self.content_object,
+            creator=self.request.user
+        )
 
     def destroy(self, request, pk=None):
         """

--- a/adhocracy4/ratings/serializers.py
+++ b/adhocracy4/ratings/serializers.py
@@ -8,7 +8,7 @@ class RatingSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Rating
-        read_only_fields = ('id', 'meta_info')
+        read_only_fields = ('id', 'meta_info', 'content_type', 'object_pk')
         exclude = ('creator', 'modified', 'created')
 
     def get_meta_info(self, obj):

--- a/adhocracy4/ratings/static/ratings/react_ratings.jsx
+++ b/adhocracy4/ratings/static/ratings/react_ratings.jsx
@@ -22,7 +22,11 @@ var RatingBox = React.createClass({
     }.bind(this))
   },
   handleRatingModify: function (number, id) {
-    api.rating.change({value: number}, id)
+    api.rating.change({
+      object_pk: this.props.objectId,
+      content_type: this.props.contentType,
+      value: number
+    }, id)
       .done(function (data) {
         this.setState({
           positiveRatings: data.meta_info.positive_ratings_on_same_object,

--- a/tests/comments/test_api.py
+++ b/tests/comments/test_api.py
@@ -3,35 +3,50 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from rest_framework import status
 
+from tests.apps.questions.models import Question
+
 
 @pytest.mark.django_db
-def test_anonymous_user_can_not_comment(apiclient):
-    url = reverse('comments-list')
-    data = {}
+@pytest.fixture
+def question_ct():
+    return ContentType.objects.get_for_model(Question)
+
+
+@pytest.mark.django_db
+def test_anonymous_user_can_not_comment(apiclient, question_ct, question):
+    url = reverse(
+        'comments-list',
+        kwargs={'content_type': question_ct.pk,
+                'object_pk': question.pk})
+    data = {
+        'comment': 'no comment',
+    }
     response = apiclient.post(url, data, format='json')
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
-def test_authenticated_user_can_not_post_invalid_data(user, apiclient):
+def test_authenticated_user_can_not_post_invalid_data(user, apiclient,
+                                                      question_ct, question):
     apiclient.force_authenticate(user=user)
-    url = reverse('comments-list')
+    url = reverse(
+        'comments-list',
+        kwargs={'content_type': question_ct.pk,
+                'object_pk': question.pk})
     data = {}
     response = apiclient.post(url, data, format='json')
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 @pytest.mark.django_db
-def test_authenticated_user_can_post_valid_data(user, question,
+def test_authenticated_user_can_post_valid_data(user, question_ct, question,
                                                 apiclient):
-    contenttype = ContentType.objects.get_for_model(question).pk
     apiclient.force_authenticate(user=user)
-    url = reverse('comments-list')
-    data = {
-        'comment': 'comment comment',
-        'object_pk': question.pk,
-        'content_type': contenttype
-    }
+    url = reverse(
+        'comments-list',
+        kwargs={'content_type': question_ct.pk,
+                'object_pk': question.pk})
+    data = {'comment': 'comment comment'}
     response = apiclient.post(url, data, format='json')
     assert response.status_code == status.HTTP_201_CREATED
 
@@ -39,20 +54,31 @@ def test_authenticated_user_can_post_valid_data(user, question,
 @pytest.mark.django_db
 def test_authenticated_user_can_edit_own_comment(comment, apiclient):
     apiclient.force_authenticate(user=comment.creator)
+    url = reverse(
+        'comments-detail',
+        kwargs={
+            'pk': comment.pk,
+            'content_type': comment.content_type.pk,
+            'object_pk': comment.object_pk
+        })
     data = {'comment': 'comment comment comment'}
-    url = reverse('comments-detail', kwargs={'pk': comment.pk})
     response = apiclient.patch(url, data, format='json')
     assert response.status_code == status.HTTP_200_OK
     assert response.data['comment'] == 'comment comment comment'
 
 
 @pytest.mark.django_db
-def test_user_can_not_edit_comment_of_other_user(another_user,
-                                                 comment,
+def test_user_can_not_edit_comment_of_other_user(another_user, comment,
                                                  apiclient):
     apiclient.force_authenticate(user=another_user)
+    url = reverse(
+        'comments-detail',
+        kwargs={
+            'pk': comment.pk,
+            'content_type': comment.content_type.pk,
+            'object_pk': comment.object_pk
+        })
     data = {'comment': 'comment comment comment'}
-    url = reverse('comments-detail', kwargs={'pk': comment.pk})
     response = apiclient.patch(url, data, format='json')
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -60,38 +86,47 @@ def test_user_can_not_edit_comment_of_other_user(another_user,
 @pytest.mark.django_db
 def test_anonymous_user_can_not_edit_comment(comment, apiclient):
     apiclient.force_authenticate(user=None)
+    url = reverse(
+        'comments-detail',
+        kwargs={
+            'pk': comment.pk,
+            'content_type': comment.content_type.pk,
+            'object_pk': comment.object_pk
+        })
     data = {'comment': 'comment comment comment'}
-    url = reverse('comments-detail', kwargs={'pk': comment.pk})
     response = apiclient.patch(url, data, format='json')
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
-def test_authenticated_user_can_reply_to_comment(another_user,
-                                                 comment,
+def test_authenticated_user_can_reply_to_comment(another_user, comment,
                                                  apiclient):
     comment_contenttype = ContentType.objects.get_for_model(comment).pk
-    url = reverse('comments-detail', kwargs={'pk': comment.pk})
-    response = apiclient.get(url)
+    original_url = reverse(
+        'comments-detail',
+        kwargs={
+            'pk': comment.pk,
+            'content_type': comment.content_type.pk,
+            'object_pk': comment.object_pk
+        })
+    response = apiclient.get(original_url)
     assert len(response.data['child_comments']) == 0
     apiclient.force_authenticate(user=another_user)
-    url = reverse('comments-list')
+    url = reverse(
+        'comments-list',
+        kwargs={'content_type': comment_contenttype,
+                'object_pk': comment.pk})
     data = {
         'comment': 'comment-reply1',
-        'object_pk': comment.pk,
-        'content_type': comment_contenttype
     }
     response = apiclient.post(url, data, format='json')
     assert response.status_code == status.HTTP_201_CREATED
     data = {
         'comment': 'comment-reply2',
-        'object_pk': comment.pk,
-        'content_type': comment_contenttype
     }
     response = apiclient.post(url, data, format='json')
     assert response.status_code == status.HTTP_201_CREATED
-    url = reverse('comments-detail', kwargs={'pk': comment.pk})
-    response = apiclient.get(url)
+    response = apiclient.get(original_url)
     assert len(response.data['child_comments']) == 2
     assert 'child_comments' not in response.data['child_comments'][0]
     assert response.data['child_comments'][0]['comment'] == 'comment-reply1'
@@ -101,16 +136,27 @@ def test_authenticated_user_can_reply_to_comment(another_user,
 @pytest.mark.django_db
 def test_anonymous_user_can_not_delete_comment(comment, apiclient):
     apiclient.force_authenticate(user=None)
-    url = reverse('comments-detail', kwargs={'pk': comment.pk})
+    url = reverse(
+        'comments-detail',
+        kwargs={
+            'pk': comment.pk,
+            'content_type': comment.content_type.pk,
+            'object_pk': comment.object_pk
+        })
     response = apiclient.delete(url)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
-def test_authenticated_user_can_not_delete_comment(comment,
-                                                   another_user,
+def test_authenticated_user_can_not_delete_comment(comment, another_user,
                                                    apiclient):
-    url = reverse('comments-detail', kwargs={'pk': comment.pk})
+    url = reverse(
+        'comments-detail',
+        kwargs={
+            'pk': comment.pk,
+            'content_type': comment.content_type.pk,
+            'object_pk': comment.object_pk
+        })
     apiclient.force_authenticate(user=another_user)
     response = apiclient.delete(url)
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -118,7 +164,13 @@ def test_authenticated_user_can_not_delete_comment(comment,
 
 @pytest.mark.django_db
 def test_creater_of_comment_can_set_removed_flag(comment, user, apiclient):
-    url = reverse('comments-detail', kwargs={'pk': comment.pk})
+    url = reverse(
+        'comments-detail',
+        kwargs={
+            'pk': comment.pk,
+            'content_type': comment.content_type.pk,
+            'object_pk': comment.object_pk
+        })
     apiclient.force_authenticate(user=user)
     response = apiclient.delete(url)
     assert response.status_code == status.HTTP_200_OK
@@ -128,7 +180,13 @@ def test_creater_of_comment_can_set_removed_flag(comment, user, apiclient):
 
 @pytest.mark.django_db
 def test_admin_of_comment_can_set_censored_flag(comment, admin, apiclient):
-    url = reverse('comments-detail', kwargs={'pk': comment.pk})
+    url = reverse(
+        'comments-detail',
+        kwargs={
+            'pk': comment.pk,
+            'content_type': comment.content_type.pk,
+            'object_pk': comment.object_pk
+        })
     apiclient.force_authenticate(user=admin)
     response = apiclient.delete(url)
     assert response.status_code == status.HTTP_200_OK
@@ -138,7 +196,13 @@ def test_admin_of_comment_can_set_censored_flag(comment, admin, apiclient):
 
 @pytest.mark.django_db
 def test_admin_of_comment_can_edit(comment, admin, apiclient):
-    url = reverse('comments-detail', kwargs={'pk': comment.pk})
+    url = reverse(
+        'comments-detail',
+        kwargs={
+            'pk': comment.pk,
+            'content_type': comment.content_type.pk,
+            'object_pk': comment.object_pk
+        })
     data = {'comment': 'comment comment comment'}
     apiclient.force_authenticate(user=admin)
     response = apiclient.patch(url, data)
@@ -150,15 +214,21 @@ def test_admin_of_comment_can_edit(comment, admin, apiclient):
 def test_rating_info(comment, user, another_user, apiclient):
     ct = ContentType.objects.get_for_model(comment)
     pk = comment.pk
-    ratings_url = reverse('ratings-list')
+    ratings_url = reverse(
+        'ratings-list', kwargs={'content_type': ct.pk,
+                                'object_pk': pk})
     apiclient.force_authenticate(user)
-    data = {
-        'value': 1,
-        'object_pk': pk,
-        'content_type': ct.pk
-    }
-    apiclient.post(ratings_url, data, format='json')
-    comment_url = reverse('comments-detail', kwargs={'pk': comment.pk})
+    data = {'value': 1}
+    response = apiclient.post(ratings_url, data, format='json')
+    assert response.status_code == status.HTTP_201_CREATED
+
+    comment_url = reverse(
+        'comments-detail',
+        kwargs={
+            'pk': comment.pk,
+            'content_type': comment.content_type.pk,
+            'object_pk': comment.object_pk
+        })
     response = apiclient.get(comment_url, format='json')
     assert response.data['ratings']['positive_ratings'] == 1
     assert response.data['ratings']['current_user_rating_value'] == 1
@@ -166,11 +236,7 @@ def test_rating_info(comment, user, another_user, apiclient):
     response = apiclient.get(comment_url, format='json')
     assert response.data['ratings']['positive_ratings'] == 1
     assert response.data['ratings']['current_user_rating_value'] is None
-    data = {
-        'value': -1,
-        'object_pk': pk,
-        'content_type': ct.pk
-    }
+    data = {'value': -1}
     apiclient.post(ratings_url, data, format='json')
     response = apiclient.get(comment_url, format='json')
     assert response.data['ratings']['positive_ratings'] == 1

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -141,9 +141,10 @@ MEDIA_URL = '/media/'
 # Adhcoracy 4
 
 A4_ORGANISATIONS_MODEL = 'a4organisations.Organisation'
-A4_RATEABLES = (('a4test_questions', 'Question'),)
-A4_REPORTABLES = (('a4test_questions', 'Question'),)
-A4_COMMENTABLES = (('a4test_questions', 'Question'),)
+A4_RATEABLES = (('a4test_questions', 'question'), ('a4comments', 'comment'),)
+A4_REPORTABLES = (('a4test_questions', 'question'),)
+A4_COMMENTABLES = (('a4test_questions', 'question'),
+                   ('a4comments', 'comment'),)
 
 # Rich text fields
 

--- a/tests/project/urls.py
+++ b/tests/project/urls.py
@@ -3,18 +3,21 @@ from django.contrib import admin
 from django.contrib.auth import views
 from rest_framework import routers
 
+from adhocracy4.api import routers as a4routers
 from adhocracy4.projects import urls as prj_urls
 from adhocracy4.ratings.api import RatingViewSet
 from adhocracy4.reports.api import ReportViewSet
 from adhocracy4.comments.api import CommentViewSet
 
 router = routers.DefaultRouter()
-router.register(r'ratings', RatingViewSet, base_name='ratings')
 router.register(r'reports', ReportViewSet, base_name='reports')
-router.register(r'comments', CommentViewSet, base_name='comments')
 
+ct_router = a4routers.ContentTypeDefaultRouter()
+ct_router.register(r'comments', CommentViewSet, base_name='comments')
+ct_router.register(r'ratings', RatingViewSet, base_name='ratings')
 
 urlpatterns = [
+    url(r'^api/', include(ct_router.urls)),
     url(r'^api/', include(router.urls)),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^projects/', include(prj_urls)),


### PR DESCRIPTION
This pull requests is the first of two trying to address #31. As mentioned in the ticket there are not enough informations in the comment API to implement proper rules for creation and listing of comment. The latter is currently solved by disabling listing in all relevant APIs (comment, reports, ratings).

In this pull-request the comment and rating api are prefixed with the content-type and object_pk of their subject.

`/comments/<pk>` ⇒ `/contenttypes/<content_type_pk>/objects/<object_pk>/comments/<pk>`
`/ratings/<pk>` ⇒ `/contenttypes/<content_type_pk>/objects/<object_pk>/ratings/<pk>`

Disadvantages:

- still not solved for reports (might not be required)
- for updating, deleting and detail view the context is not required (but still given)
- long urls
- custom router

There will be a second pull-request for introducing the permissions themself.