### PR TITLE
Add an ItemForm which should be used with Item*Views

### DIFF
--- a/adhocracy4/categories/forms.py
+++ b/adhocracy4/categories/forms.py
@@ -1,14 +1,14 @@
 from django import forms
 
+from adhocracy4.modules import forms as module_forms
 from adhocracy4.categories import models as category_models
 
 
-class CategorizableForm(forms.ModelForm):
+class CategorizableForm(module_forms.ItemForm):
 
     def __init__(self, *args, **kwargs):
-        module = kwargs.pop('module')
         super().__init__(*args, **kwargs)
-        queryset = category_models.Category.objects.filter(module=module)
+        queryset = category_models.Category.objects.filter(module=self.module)
         self.fields['category'] = forms.ModelChoiceField(
             queryset=queryset,
             empty_label=None,

--- a/adhocracy4/modules/forms.py
+++ b/adhocracy4/modules/forms.py
@@ -1,0 +1,12 @@
+from django import forms
+
+
+class ItemForm(forms.ModelForm):
+    """
+    Base form for items indented to use together with Item*Views.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.pop('module', None)
+        self.settings_instance = kwargs.pop('settings_instance', None)
+        super(ItemForm, self).__init__(*args, **kwargs)

--- a/tests/apps/questions/forms.py
+++ b/tests/apps/questions/forms.py
@@ -1,0 +1,9 @@
+from adhocracy4.modules import forms as module_forms
+from . import models
+
+
+class QuestionForm(module_forms.ItemForm):
+
+    class Meta:
+        model = models.Question
+        fields = ['text']

--- a/tests/apps/questions/views.py
+++ b/tests/apps/questions/views.py
@@ -2,7 +2,7 @@ import django_filters
 
 from adhocracy4.modules import views as module_views
 
-from . import models
+from . import forms, models
 
 
 class QuestionFilterSet(django_filters.FilterSet):
@@ -15,3 +15,13 @@ class QuestionFilterSet(django_filters.FilterSet):
 class QuestionList(module_views.ItemListView):
     model = models.Question
     filter_set = QuestionFilterSet
+
+
+class QuestionCreateForm(module_views.ItemCreateView):
+    model = models.Question
+    form_class = forms.QuestionForm
+
+
+class QuestionUpdateForm(module_views.ItemUpdateView):
+    model = models.Question
+    form_class = forms.QuestionForm

--- a/tests/modules/test_module_forms.py
+++ b/tests/modules/test_module_forms.py
@@ -1,0 +1,35 @@
+import pytest
+from tests.apps.questions import views as q_views
+
+
+@pytest.mark.django_db
+def test_item_create_form(rf, phase):
+    module = phase.module
+    settings_instance = \
+        getattr(module, 'settings_instance', None)
+
+    view = q_views.QuestionCreateForm()
+    view.request = rf.get('/create/module/question/')
+    view.module = module
+
+    form = view.get_form()
+
+    assert form.module == module
+    assert form.settings_instance == settings_instance
+
+
+@pytest.mark.django_db
+def test_item_update_form(rf, question):
+    object = question
+    module = object.module
+    settings_instance = \
+        getattr(module, 'settings_instance', None)
+
+    view = q_views.QuestionUpdateForm()
+    view.request = rf.get('/1/update/')
+    view.object = question
+
+    form = view.get_form()
+
+    assert form.module == module
+    assert form.settings_instance == settings_instance

--- a/tests/modules/test_module_forms.py
+++ b/tests/modules/test_module_forms.py
@@ -20,8 +20,7 @@ def test_item_create_form(rf, phase):
 
 @pytest.mark.django_db
 def test_item_update_form(rf, question):
-    object = question
-    module = object.module
+    module = question.module
     settings_instance = \
         getattr(module, 'settings_instance', None)
 


### PR DESCRIPTION
Item*Views are initializing forms with the additional `module` and
`settings_instance` keyword arguments. The ItemForm will take those from
the arguments dict and store them as object attributes.