### PR TITLE
fix bug with tiles

### DIFF
--- a/adhocracy4/maps/static/a4maps/map_choose_polygon.js
+++ b/adhocracy4/maps/static/a4maps/map_choose_polygon.js
@@ -93,6 +93,12 @@ window.jQuery(document).ready(function () {
       $('#id_' + name).val(JSON.stringify(shape))
     })
 
+    $(document).on('shown.bs.tab', function(event) {
+      // tiles don't load properly when hidden initially (e.g. by tabs)
+      // see https://github.com/tombatossals/angular-leaflet-directive/issues/49
+      map.invalidateSize()
+    })
+
     $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
       if (!mapVisible) {
         map.invalidateSize().fitBounds(getBasePolygon(L, polygon, bbox))


### PR DESCRIPTION
When the map is hidden initially and leaflet initialises tiles don't show properly sometimes. See https://github.com/tombatossals/angular-leaflet-directive/issues/49

Something that also occurs on opin: 
<img width="902" alt="screen shot 2017-04-11 at 12 13 02" src="https://cloud.githubusercontent.com/assets/16354712/24904283/45769f9c-1eb0-11e7-8ec7-1bf9b274ed5b.png">
