### PR TITLE
fix bug with initially hidden map

### DIFF
--- a/adhocracy4/maps/static/a4maps/map_choose_polygon.js
+++ b/adhocracy4/maps/static/a4maps/map_choose_polygon.js
@@ -94,10 +94,7 @@ window.jQuery(document).ready(function () {
     })
 
     $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-      if (!mapVisible) {
-        map.invalidateSize().fitBounds(getBasePolygon(L, polygon, bbox))
-        mapVisible = true
-      }
+      map.invalidateSize().fitBounds(getBasePolygon(L, polygon, bbox))
     })
   })
 })


### PR DESCRIPTION
The check that was done to do the `map.invalidateSize()` was too broad. When clicking 'result' first and then switching to the middle tab, the `mapVisible` was set already to true. Also: when resizing while not in that particular tab the bug would occur again as well. Now it's just on every click. We can observe if this will have any performance issues but I doubt it.

<img width="902" alt="screen shot 2017-04-11 at 12 13 02" src="https://cloud.githubusercontent.com/assets/16354712/24907249/af43e320-1ebb-11e7-8526-aa056b680058.png">
