### PR TITLE
draft: polygon presets

### DIFF
--- a/adhocracy4/maps/static/a4maps/map_choose_polygon.js
+++ b/adhocracy4/maps/static/a4maps/map_choose_polygon.js
@@ -99,5 +99,19 @@ window.jQuery(document).ready(function () {
         mapVisible = true
       }
     })
+
+    $('#select_' + name).on('change', function (event) {
+      var geoJson = event.target.value
+      drawnItems.clearLayers()
+      if (geoJson) {
+        var group = L.geoJson(JSON.parse(geoJson), {
+          style: polygonStyle
+        })
+        group.eachLayer(function (layer) {
+          drawnItems.addLayer(layer)
+        })
+      }
+      $('#id_' + name).val(geoJson)
+    })
   })
 })

--- a/adhocracy4/maps/templates/a4maps/map_choose_polygon_widget.html
+++ b/adhocracy4/maps/templates/a4maps/map_choose_polygon_widget.html
@@ -1,3 +1,8 @@
+<select id="select_{{ name }}">
+    <option value="">---</option>
+    <option value="{ &quot;type&quot;:&quot;FeatureCollection&quot;, &quot;features&quot;:[ { &quot;properties&quot;:{}, &quot;geometry&quot;:{ &quot;coordinates&quot;:[ [ [ 12.918548583984375, 52.39608209563086 ], [ 13.226165771484375, 52.72667630387682 ], [ 13.748016357421875, 52.553341507495865 ], [ 13.599700927734375, 52.39273004324774 ], [ 13.160247802734375, 52.39273004324774 ], [ 12.918548583984375, 52.39608209563086 ] ] ], &quot;type&quot;:&quot;Polygon&quot; }, &quot;type&quot;:&quot;Feature&quot; } ] }">Some polygon</option>
+</select>
+
 <div
     style="height: 300px;"
     data-map="choose_polygon"


### PR DESCRIPTION
This is a first draft for polygon presets. There are several possible UI concepts for this:

1. Show a select by default. One option is "custom". If this option is selected, the map widget is shown.
2. Show a select and a button. When the button is clicked, the select is disabled and the map widget is shown.
3. Both map and select are shown. When a user selects a preset in the select, it is loaded into the map (replacing the previous content).

We expect that in the case of meinberlin, about 70% of projects will use an unaltered polygon preset. So it should be a prominent option to use a preset while also making it easy to define a custom polygon.

This pull requests implements the third option. It seems to be the most usable (e.g. it allows to edit a preset after selection) and is also quite easy to implement.

Still to do:

-   get presets from the backend
-   only include the select if there are any presets
-   ask the user for confirmation before replacing the content (required?)
-   add a label/help text to the select