### PR TITLE
Make reports available for arbitrary entries

### DIFF
--- a/adhocracy4/comments/static/comments/Comment.jsx
+++ b/adhocracy4/comments/static/comments/Comment.jsx
@@ -1,4 +1,4 @@
-var ReportModal = require('../../../reports/static/reports/react_reports')
+var ReportModal = require('../../../reports/static/reports/react_reports').ReportModal
 var RatingBox = require('../../../ratings/static/ratings/react_ratings').RatingBox
 var Modal = require('../../../static/Modal')
 var CommentEditForm = require('./CommentEditForm')

--- a/adhocracy4/reports/static/reports/ReportModal.jsx
+++ b/adhocracy4/reports/static/reports/ReportModal.jsx
@@ -1,0 +1,83 @@
+let api = require('../../../static/api')
+let Modal = require('../../../static/Modal')
+
+let $ = require('jquery')
+let React = require('react')
+let django = require('django')
+
+const ReportModal = React.createClass({
+  getInitialState: function () {
+    return {
+      report: '',
+      showSuccessMessage: false,
+      showErrorMessage: false,
+      showReportForm: true
+    }
+  },
+  handleTextChange: function (e) {
+    this.setState({report: e.target.value})
+  },
+  resetModal: function () {
+    if (!$('#' + this.props.name).is(':visible')) {
+      this.setState({
+        report: '',
+        showSuccessMessage: false,
+        showErrorMessage: false,
+        showReportForm: true,
+        errors: null
+      })
+    } else {
+      setTimeout(this.resetModal, 500)
+    }
+  },
+  closeModal: function () {
+    $('#' + this.props.name).modal('hide')
+    this.resetModal()
+  },
+  submitReport: function () {
+    api.report.submit({
+      description: this.state.report,
+      content_type: this.props.contentType,
+      object_pk: this.props.objectId
+    })
+      .done(function () {
+        this.setState({
+          report: '',
+          showSuccessMessage: true,
+          showReportForm: false,
+          showErrorMessage: false
+        })
+      }.bind(this))
+  },
+  render: function () {
+    let partials = {}
+    if (this.state.showSuccessMessage) {
+      partials.title = (<span><i className="fa fa-check" /> Thank you! We are taking care of it.</span>)
+      partials.hideFooter = true
+      partials.bodyClass = 'success'
+    } else if (this.state.showReportForm) {
+      partials.title = this.props.title
+      partials.body = (
+        <div className="form-group">
+          <textarea rows="5" className="form-control report-message" value={this.state.report}
+            placeholder={django.gettext('Your message here')} onChange={this.handleTextChange} />
+          {this.state.errors && <span className="help-block">{this.state.errors.description}</span>}
+        </div>
+      )
+    }
+
+    return (
+      <Modal
+        abort={this.props.abort}
+        name={this.props.name}
+        closeHandler={this.closeModal}
+        submitHandler={this.submitReport}
+        action={django.gettext('Send Report')}
+        partials={partials}
+        dismissOnSubmit={false}
+      />
+    )
+  }
+})
+
+module.exports = ReportModal

--- a/adhocracy4/reports/static/reports/react_reports.jsx
+++ b/adhocracy4/reports/static/reports/react_reports.jsx
@@ -1,83 +1,26 @@
-let api = require('../../../static/api')
-let Modal = require('../../../static/Modal')
-
-let $ = require('jquery')
-let React = require('react')
+var ReportModal = require('./ReportModal')
+var React = require('react')
+var ReactDOM = require('react-dom')
 let django = require('django')
 
-const ReportModal = React.createClass({
-  getInitialState: function () {
-    return {
-      report: '',
-      showSuccessMessage: false,
-      showErrorMessage: false,
-      showReportForm: true
-    }
-  },
-  handleTextChange: function (e) {
-    this.setState({report: e.target.value})
-  },
-  resetModal: function () {
-    if (!$('#' + this.props.name).is(':visible')) {
-      this.setState({
-        report: '',
-        showSuccessMessage: false,
-        showErrorMessage: false,
-        showReportForm: true,
-        errors: null
-      })
-    } else {
-      setTimeout(this.resetModal, 500)
-    }
-  },
-  closeModal: function () {
-    $('#' + this.props.name).modal('hide')
-    this.resetModal()
-  },
-  submitReport: function () {
-    api.report.submit({
-      description: this.state.report,
-      content_type: this.props.contentType,
-      object_pk: this.props.objectId
-    })
-      .done(function () {
-        this.setState({
-          report: '',
-          showSuccessMessage: true,
-          showReportForm: false,
-          showErrorMessage: false
-        })
-      }.bind(this))
-  },
-  render: function () {
-    let partials = {}
-    if (this.state.showSuccessMessage) {
-      partials.title = (<span><i className="fa fa-check" /> Thank you! We are taking care of it.</span>)
-      partials.hideFooter = true
-      partials.bodyClass = 'success'
-    } else if (this.state.showReportForm) {
-      partials.title = this.props.title
-      partials.body = (
-        <div className="form-group">
-          <textarea rows="5" className="form-control report-message" value={this.state.report}
-            placeholder={django.gettext('Your message here')} onChange={this.handleTextChange} />
-          {this.state.errors && <span className="help-block">{this.state.errors.description}</span>}
-        </div>
-      )
-    }
+module.exports.ReportModal = ReportModal
 
-    return (
-      <Modal
-        abort={this.props.abort}
-        name={this.props.name}
-        closeHandler={this.closeModal}
-        submitHandler={this.submitReport}
-        action={django.gettext('Send Report')}
-        partials={partials}
-        dismissOnSubmit={false}
-      />
-    )
-  }
-})
+module.exports.renderReports = function (mountpoint) {
+  let el = document.getElementById(mountpoint)
+  let props = JSON.parse(el.getAttribute('data-attributes'))
 
-module.exports = ReportModal
+  el.setAttribute('href', '#' + props.modalName)
+  el.setAttribute('data-toggle', 'modal')
+
+  let container = document.createElement('div')
+  document.body.appendChild(container)
+
+  ReactDOM.render((
+    <ReportModal
+      name={props.modalName}
+      title={django.gettext('Are you sure you want to report this item?')}
+      btnStyle="cta"
+      objectId={props.objectId}
+      contentType={props.contentType} />
+  ), container)
+}

--- a/adhocracy4/reports/templatetags/react_reports.py
+++ b/adhocracy4/reports/templatetags/react_reports.py
@@ -1,0 +1,46 @@
+import json
+
+from django import template
+from django.contrib.contenttypes.models import ContentType
+from django.utils.html import format_html
+from django.utils.translation import ugettext as _
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def react_reports(obj, text=None, **kwargs):
+    contenttype = ContentType.objects.get_for_model(obj)
+
+    mountpoint = 'report_for_{contenttype}_{pk}'.format(
+        contenttype=contenttype.pk,
+        pk=obj.pk
+    )
+
+    modal_name = '{mountpoint}_modal'.format(mountpoint=mountpoint)
+
+    attributes = {
+        'contentType': contenttype.pk,
+        'objectId': obj.pk,
+        'modalName': modal_name,
+    }
+
+    if text is None:
+        text = _('Report')
+
+    if 'class' in kwargs:
+        class_names = kwargs['class']
+
+    return format_html(
+        (
+            '<a href="#{modal_name}" id="{mountpoint}"'
+            ' data-attributes="{attributes}" class="{class_names}">{text}</a>'
+            "<script>window.adhocracy4.renderReports('{mountpoint}')</script>"
+        ),
+        attributes=json.dumps(attributes),
+        mountpoint=mountpoint,
+        modal_name=modal_name,
+        class_names=class_names,
+        text=text,
+    )

--- a/tests/reports/test_report_templatetags.py
+++ b/tests/reports/test_report_templatetags.py
@@ -29,8 +29,6 @@ def react_reports_render_template(template, rf, question):
         r'</script>$'
     ).format(mountpoint=mountpoint, modal_name=modal_name)
 
-    print(helpers.render_template(template, context))
-    print(expected)
     match = re.match(expected, helpers.render_template(template, context))
     assert match
     assert match.group('props')

--- a/tests/reports/test_report_templatetags.py
+++ b/tests/reports/test_report_templatetags.py
@@ -1,0 +1,61 @@
+import html
+import json
+import pytest
+import re
+
+from django.contrib.contenttypes.models import ContentType
+
+from adhocracy4.test import helpers
+
+
+def react_reports_render_template(template, rf, question):
+    request = rf.get('/')
+    template = '{% load react_reports %}' + template
+    context = {'request': request, "question": question}
+
+    content_type = ContentType.objects.get_for_model(question)
+
+    mountpoint = 'report_for_{contenttype}_{pk}'.format(
+        contenttype=content_type.id,
+        pk=question.id
+    )
+    modal_name = '{mountpoint}_modal'.format(mountpoint=mountpoint)
+
+    expected = (
+        r'^<a href=\"#{modal_name}\" id=\"{mountpoint}\"'
+        r' data-attributes=\"(?P<props>{{.+}})\"'
+        r' class=\"(?P<class_names>.*)\">(?P<text>.+)</a>'
+        r'<script>window.adhocracy4.renderReports\(\'{mountpoint}\'\)'
+        r'</script>$'
+    ).format(mountpoint=mountpoint, modal_name=modal_name)
+
+    print(helpers.render_template(template, context))
+    print(expected)
+    match = re.match(expected, helpers.render_template(template, context))
+    assert match
+    assert match.group('props')
+    props = json.loads(html.unescape(match.group('props')))
+    assert props['contentType'] == content_type.id
+    assert props['objectId'] == question.id
+    assert props['modalName'] == modal_name
+    del props['contentType']
+    del props['objectId']
+    del props['modalName']
+
+    assert match.group('class_names')
+    assert match.group('text')
+
+    return {
+        'props': props,
+        'class_names': html.unescape(match.group('class_names')),
+        'text': html.unescape(match.group('text'))
+    }
+
+
+@pytest.mark.django_db
+def test_react_reports(rf, question):
+    template = '{% react_reports question text="test" class="fancy class" %}'
+    result = react_reports_render_template(template, rf, question)
+    assert result['props'] == {}
+    assert result['class_names'] == 'fancy class'
+    assert result['text'] == 'test'


### PR DESCRIPTION
To make reporting available for arbitrary entries a new template tag
`react_reports` and an accompanying react function are introduced.
The template tag creates a link and the javascript to call the react
function to initialize the modal.
The modals is inserted as a new child of `body` to prevent problems when
the tag is used in f.ex. collapsible menus.