### PR TITLE
Consistent permission naming

### DIFF
--- a/adhocracy4/modules/predicates.py
+++ b/adhocracy4/modules/predicates.py
@@ -46,13 +46,13 @@ def is_allowed_view_item(user, item):
             is_public_context(user, item))
 
 
-def is_allowed_create_item(item_class):
+def is_allowed_add_item(item_class):
     @rules.predicate
-    def _create_item(user, item):
+    def _add_item(user, item):
         return (is_project_admin(user, item) |
                 (is_context_member(user, item) &
-                 phase_predicates.phase_allows_create(item_class)(user, item)))
-    return _create_item
+                 phase_predicates.phase_allows_add(item_class)(user, item)))
+    return _add_item
 
 
 @rules.predicate
@@ -70,8 +70,8 @@ def is_allowed_comment_item(user, item):
 
 
 @rules.predicate
-def is_allowed_modify_item(user, item):
+def is_allowed_change_item(user, item):
     return (is_project_admin(user, item) |
             (is_context_member(user, item) &
              is_owner(user, item) &
-             phase_predicates.phase_allows_modify(user, item)))
+             phase_predicates.phase_allows_change(user, item)))

--- a/adhocracy4/phases/predicates.py
+++ b/adhocracy4/phases/predicates.py
@@ -9,15 +9,15 @@ def has_feature_active(project, model, feature):
 
 
 @rules.predicate
-def phase_allows_modify(user, item):
+def phase_allows_change(user, item):
     return has_feature_active(item.project, item.__class__, 'crud')
 
 
-def phase_allows_create(item_class):
+def phase_allows_add(item_class):
     @rules.predicate
-    def _create_predicate(user, module):
+    def _add_predicate(user, module):
         return has_feature_active(module.project, item_class, 'crud')
-    return _create_predicate
+    return _add_predicate
 
 
 @rules.predicate

--- a/adhocracy4/projects/rules.py
+++ b/adhocracy4/projects/rules.py
@@ -5,6 +5,11 @@ from adhocracy4.organisations.predicates import is_initiator
 
 from .predicates import is_live, is_member, is_public
 
+
+rules.add_perm('a4projects.add_project',
+               is_superuser | is_initiator)
+
+
 rules.add_perm('a4projects.change_project',
                is_superuser | is_initiator)
 

--- a/adhocracy4/projects/rules.py
+++ b/adhocracy4/projects/rules.py
@@ -5,7 +5,7 @@ from adhocracy4.organisations.predicates import is_initiator
 
 from .predicates import is_live, is_member, is_public
 
-rules.add_perm('a4projects.edit_project',
+rules.add_perm('a4projects.change_project',
                is_superuser | is_initiator)
 
 


### PR DESCRIPTION
In https://github.com/liqd/adhocracy4/pull/60 we decided to use the permission terms view, add, change, delete.

Renaming the respective predicates for consistency.