### PR TITLE
refactor url replace logic and update documents api url

### DIFF
--- a/adhocracy4/comments/static/comments/CommentEditForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentEditForm.jsx
@@ -16,8 +16,10 @@ var CommentEditForm = React.createClass({
     }
     this.props.onCommentSubmit({
       comment: comment,
-      object_pk: this.props.subjectId,
-      content_type: this.props.subjectType
+      urlReplaces: {
+        objectPk: this.props.subjectId,
+        contentTypeId: this.props.subjectType,
+      },
     })
   },
   render: function () {

--- a/adhocracy4/comments/static/comments/CommentForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentForm.jsx
@@ -18,8 +18,10 @@ let CommentForm = React.createClass({
     }
     this.props.onCommentSubmit({
       comment: comment,
-      object_pk: this.props.subjectId,
-      content_type: this.props.subjectType
+      urlReplaces: {
+        objectPk: this.props.subjectId,
+        contentTypeId: this.props.subjectType,
+      },
     }, this.props.parentIndex)
     this.setState({comment: ''})
   },

--- a/adhocracy4/ratings/static/ratings/react_ratings.jsx
+++ b/adhocracy4/ratings/static/ratings/react_ratings.jsx
@@ -8,8 +8,10 @@ var classnames = require('classnames')
 var RatingBox = React.createClass({
   handleRatingCreate: function (number) {
     api.rating.add({
-      object_pk: this.props.objectId,
-      content_type: this.props.contentType,
+      urlReplaces: {
+        objectPk: this.props.objectId,
+        contentTypeId: this.props.contentType,
+      },
       value: number
     }).done(function (data) {
       this.setState({
@@ -23,8 +25,10 @@ var RatingBox = React.createClass({
   },
   handleRatingModify: function (number, id) {
     api.rating.change({
-      object_pk: this.props.objectId,
-      content_type: this.props.contentType,
+      urlReplaces: {
+        objectPk: this.props.objectId,
+        contentTypeId: this.props.contentType,
+      },
       value: number
     }, id)
       .done(function (data) {

--- a/adhocracy4/static/api.js
+++ b/adhocracy4/static/api.js
@@ -12,11 +12,8 @@ var baseURL = '/api/'
 var api = (function () {
   var urls = {
     report: baseURL + 'reports/',
-    document: baseURL + 'documents/',
-    follow: baseURL + 'follows/'
-  }
-
-  var genericUrls = {
+    document: baseURL + '/modules/$moduleId/documents/',
+    follow: baseURL + 'follows/',
     comment: baseURL + 'contenttypes/$contentTypeId/objects/$objectPk/comments/',
     rating: baseURL + 'contenttypes/$contentTypeId/objects/$objectPk/ratings/'
   }
@@ -31,16 +28,13 @@ var api = (function () {
       id = null
     }
 
-    var url
-    if (urls.hasOwnProperty(endpoint)) {
-      url = urls[endpoint]
-    } else {
-      url = genericUrls[endpoint]
-        .replace('$contentTypeId', data['content_type'])
-        .replace('$objectPk', data['object_pk'])
+    var url = urls[endpoint]
+    if (data.urlReplaces) {
+      url = url.replace(/\$(\w+?)\b/g, (match, group) => {
+        return data.urlReplaces[group]
+      })
       data = $.extend({}, data)
-      delete data.content_type
-      delete data.object_pk
+      delete data.urlReplaces
     }
 
     if (typeof id === 'number' || typeof id === 'string') {

--- a/adhocracy4/static/api.js
+++ b/adhocracy4/static/api.js
@@ -12,7 +12,7 @@ var baseURL = '/api/'
 var api = (function () {
   var urls = {
     report: baseURL + 'reports/',
-    document: baseURL + '/modules/$moduleId/documents/',
+    document: baseURL + 'modules/$moduleId/documents/',
     follow: baseURL + 'follows/',
     comment: baseURL + 'contenttypes/$contentTypeId/objects/$objectPk/comments/',
     rating: baseURL + 'contenttypes/$contentTypeId/objects/$objectPk/ratings/'


### PR DESCRIPTION
You'll need to update the call to documents endpoints. see: https://github.com/liqd/a4-meinberlin/pull/254/commits/04c6cc29d243c4a258034828305c4ec7718b9ab8 

Also adds a generic url replace logic.

Assuming you want to post to an endpoint's url `api/contenttypes/$contentTypeId/objects/$objectPk/comments/` you now make a call to `api.comments.change` with an object `urlReplaces` in data. JS will look for the keys `contentTypeId` and `objectPk` in that object and replace the placeholders in the url with the particular value in `urlReplaces`.