### PR TITLE
add project follows

### DIFF
--- a/adhocracy4/api/mixins.py
+++ b/adhocracy4/api/mixins.py
@@ -1,6 +1,9 @@
 from django.contrib.contenttypes.models import ContentType
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.request import clone_request
+from rest_framework.response import Response
 
 from adhocracy4.modules import models as module_models
 
@@ -64,3 +67,47 @@ class ModuleMixin:
             module_models.Module,
             pk=self.module_pk
         )
+
+
+class AllowPUTAsCreateMixin(object):
+    """
+    The following mixin class may be used in order to support PUT-as-create
+    behavior for incoming requests.
+    """
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.pop('partial', False)
+        instance = self.get_object_or_none()
+        serializer = self.get_serializer(instance,
+                                         data=request.data,
+                                         partial=partial)
+        serializer.is_valid(raise_exception=True)
+
+        if instance is None:
+            lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+            lookup_value = self.kwargs[lookup_url_kwarg]
+            extra_kwargs = {self.lookup_field: lookup_value}
+            serializer.save(**extra_kwargs)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+        serializer.save()
+        return Response(serializer.data)
+
+    def partial_update(self, request, *args, **kwargs):
+        kwargs['partial'] = True
+        return self.update(request, *args, **kwargs)
+
+    def get_object_or_none(self):
+        try:
+            return self.get_object()
+        except Http404:
+            if self.request.method == 'PUT':
+                # For PUT-as-create operation, we need to ensure that we have
+                # relevant permissions, as if this was a POST request.  This
+                # will either raise a PermissionDenied exception, or simply
+                # return None.
+                # xi: checks permission on wrong path
+                self.check_permissions(clone_request(self.request, 'POST'))
+            else:
+                # PATCH requests where the object does not exist should still
+                # return a 404 response.
+                raise

--- a/adhocracy4/follows/admin.py
+++ b/adhocracy4/follows/admin.py
@@ -1,0 +1,10 @@
+from django.contrib import admin
+
+from . import models
+
+
+class FollowAdmin(admin.ModelAdmin):
+    list_display = ('__str__', 'creator', 'project', 'enabled')
+
+
+admin.site.register(models.Follow, FollowAdmin)

--- a/adhocracy4/follows/api.py
+++ b/adhocracy4/follows/api.py
@@ -1,0 +1,23 @@
+from rest_framework import filters, mixins, permissions, viewsets
+
+from adhocracy4.api.mixins import AllowPUTAsCreateMixin
+
+from . import models
+from .serializers import FollowSerializer
+
+
+class FollowViewSet(AllowPUTAsCreateMixin,
+                    mixins.ListModelMixin,
+                    mixins.RetrieveModelMixin,
+                    mixins.UpdateModelMixin,
+                    viewsets.GenericViewSet):
+
+    lookup_field = 'project__slug'
+    queryset = models.Follow.objects
+    serializer_class = FollowSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+    filter_backends = (filters.DjangoFilterBackend,)
+    filter_fields = ('enabled', )
+
+    def get_queryset(self):
+        return self.queryset.filter(creator=self.request.user)

--- a/adhocracy4/follows/apps.py
+++ b/adhocracy4/follows/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class FollowsConfig(AppConfig):
+    name = 'adhocracy4.follows'
+    label = 'a4follows'
+
+    def ready(self):
+        import adhocracy4.follows.signals  # noqa:F401

--- a/adhocracy4/follows/migrations/0001_initial.py
+++ b/adhocracy4/follows/migrations/0001_initial.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.utils.timezone
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('a4projects', '0006_project_typ'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Follow',
+            fields=[
+                ('id', models.AutoField(serialize=False, auto_created=True, verbose_name='ID', primary_key=True)),
+                ('created', models.DateTimeField(default=django.utils.timezone.now, editable=False)),
+                ('modified', models.DateTimeField(null=True, blank=True, editable=False)),
+                ('enabled', models.BooleanField(default=True)),
+                ('creator', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('project', models.ForeignKey(to='a4projects.Project')),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='follow',
+            unique_together=set([('project', 'creator')]),
+        ),
+    ]

--- a/adhocracy4/follows/models.py
+++ b/adhocracy4/follows/models.py
@@ -1,0 +1,15 @@
+from django.db import models
+
+from adhocracy4.models import base
+from adhocracy4.projects import models as project_models
+
+
+class Follow(base.UserGeneratedContentModel):
+    project = models.ForeignKey(project_models.Project)
+    enabled = models.BooleanField(default=True)
+
+    class Meta:
+        unique_together = ('project', 'creator')
+
+    def __str__(self):
+        return 'Follow({}, enabled={})'.format(self.project, self.enabled)

--- a/adhocracy4/follows/serializers.py
+++ b/adhocracy4/follows/serializers.py
@@ -1,0 +1,32 @@
+from rest_framework import serializers
+
+from adhocracy4.projects import models as project_models
+
+from . import models
+
+
+class FollowSerializer(serializers.ModelSerializer):
+
+    project = serializers.SlugRelatedField(read_only=True, slug_field='slug')
+    follows = serializers.SerializerMethodField()
+    creator = serializers.HiddenField(
+        default=serializers.CurrentUserDefault()
+    )
+
+    class Meta:
+        model = models.Follow
+        read_only_field = ('project', 'creator', 'created', 'modified')
+        exclude = ('id',)
+
+    def save(self, *args, **kwargs):
+        if 'project__slug' in kwargs:
+            slug = kwargs.pop('project__slug')
+            project = project_models.Project.objects.get(slug=slug)
+            kwargs['project'] = project
+        return super().save(*args, **kwargs)
+
+    def get_follows(self, obj):
+        return models.Follow.objects.filter(
+            project=obj.project,
+            enabled=True
+        ).count()

--- a/adhocracy4/follows/signals.py
+++ b/adhocracy4/follows/signals.py
@@ -1,0 +1,16 @@
+from django.db.models.signals import post_save
+
+from . import models
+
+
+def autofollow_hook(instance, **kwargs):
+    if hasattr(instance.project, 'id'):
+        models.Follow.objects.get_or_create(
+            project=instance.project,
+            creator=instance.creator,
+            defaults={
+                'enabled': True,
+            })
+
+
+post_save.connect(autofollow_hook, 'a4comments.Comment')

--- a/adhocracy4/follows/signals.py
+++ b/adhocracy4/follows/signals.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db.models.signals import post_save
 
 from . import models
@@ -13,4 +14,5 @@ def autofollow_hook(instance, **kwargs):
             })
 
 
-post_save.connect(autofollow_hook, 'a4comments.Comment')
+for model in settings.A4_AUTO_FOLLOWABLES:
+    post_save.connect(autofollow_hook, model)

--- a/adhocracy4/follows/static/follows/FollowButton.jsx
+++ b/adhocracy4/follows/static/follows/FollowButton.jsx
@@ -1,0 +1,49 @@
+var api = require('adhocracy4').api
+var django = require('django')
+var React = require('react')
+
+var FollowButton = React.createClass({
+  getInitialState: function () {
+    return {
+      followed: undefined,
+      follows: 0
+    }
+  },
+  toggleFollow: function () {
+    api.follow.change({ enabled: !this.state.followed }, this.props.project)
+       .done((follow) => {
+         this.setState({
+           followed: follow.enabled,
+           follows: follow.follows
+         })
+       })
+  },
+  componentDidMount: function () {
+    api.follow.get(this.props.project)
+       .done((follow) => {
+         this.setState({
+           followed: follow.enabled,
+           follows: follow.follows
+         })
+       })
+       .fail((response) => {
+         response.status === 404
+         this.setState({
+           followed: false
+         })
+       })
+  },
+  render: function () {
+    return (
+      <span className="btngroup btngroup-gray">
+        <button className="btn btn-sm btn-dark btn-primary" type="button" onClick={this.toggleFollow}>
+          <i className={this.state.followed ? 'fa fa-star' : 'fa fa-star-o'} aria-hidden="true" />
+          &nbsp;{this.state.followed ? django.gettext('Unfollow') : django.gettext('Follow')}
+        </button>
+        <span className="btn btn-sm btn-dark btn-primary">{this.state.follows}</span>
+      </span>
+    )
+  }
+})
+
+module.exports = FollowButton

--- a/adhocracy4/follows/static/follows/FollowButton.jsx
+++ b/adhocracy4/follows/static/follows/FollowButton.jsx
@@ -1,4 +1,4 @@
-var api = require('adhocracy4').api
+var api = require('../../../static/api')
 var django = require('django')
 var React = require('react')
 
@@ -27,10 +27,11 @@ var FollowButton = React.createClass({
          })
        })
        .fail((response) => {
-         response.status === 404
-         this.setState({
-           followed: false
-         })
+         if (response.status === 404) {
+           this.setState({
+             followed: false
+           })
+         }
        })
   },
   render: function () {

--- a/adhocracy4/follows/static/follows/react_follows.jsx
+++ b/adhocracy4/follows/static/follows/react_follows.jsx
@@ -2,7 +2,8 @@ var FollowButton = require('./FollowButton')
 var React = require('react')
 var ReactDOM = require('react-dom')
 
-module.exports.renderFollow = function (el) {
+module.exports.renderFollow = function (mountpoint) {
+  let el = document.getElementById(mountpoint)
   let project = el.getAttribute('data-project')
   ReactDOM.render(<FollowButton project={project} />, el)
 }

--- a/adhocracy4/follows/static/follows/react_follows.jsx
+++ b/adhocracy4/follows/static/follows/react_follows.jsx
@@ -1,0 +1,8 @@
+var FollowButton = require('./FollowButton')
+var React = require('react')
+var ReactDOM = require('react-dom')
+
+module.exports.renderFollow = function (el) {
+  let project = el.getAttribute('data-project')
+  ReactDOM.render(<FollowButton project={project} />, el)
+}

--- a/adhocracy4/follows/templatetags/follow_tags.py
+++ b/adhocracy4/follows/templatetags/follow_tags.py
@@ -1,0 +1,17 @@
+from django import template
+
+from .. import models
+
+register = template.Library()
+
+
+@register.assignment_tag()
+def is_following(user, project):
+    return (
+        user.is_authenticated() and
+        models.Follow.objects.filter(
+            enabled=True,
+            project=project,
+            creator=user
+        ).exists()
+    )

--- a/adhocracy4/follows/templatetags/react_follows.py
+++ b/adhocracy4/follows/templatetags/react_follows.py
@@ -1,0 +1,12 @@
+from django import template
+from django.utils.html import format_html
+
+register = template.Library()
+
+
+@register.simple_tag()
+def react_follows(project):
+    return format_html(
+        '<span data-euth-widget="follows" data-project={project}></span>',
+        project=project.slug
+    )

--- a/adhocracy4/follows/templatetags/react_follows.py
+++ b/adhocracy4/follows/templatetags/react_follows.py
@@ -6,7 +6,13 @@ register = template.Library()
 
 @register.simple_tag()
 def react_follows(project):
+    mountpoint = 'follows_for_project_{pk}'.format(pk=project.pk)
+
     return format_html(
-        '<span data-euth-widget="follows" data-project={project}></span>',
-        project=project.slug
+        (
+            '<span id="{mountpoint}" data-project={project}></span>'
+            "<script>window.adhocracy4.renderFollow('{mountpoint}')</script>"
+        ),
+        project=project.slug,
+        mountpoint=mountpoint
     )

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = {
   ratings: require('./adhocracy4/ratings/static/ratings/react_ratings.jsx'),
   comments: require('./adhocracy4/comments/static/comments/react_comments.jsx'),
   reports: require('./adhocracy4/reports/static/reports/react_reports.jsx'),
-  follows: require('./adhocracy4/reports/static/reports/react_follows.jsx'),
+  follows: require('./adhocracy4/follows/static/follows/react_follows.jsx'),
   config: require('./adhocracy4/static/config.js'),
   api: require('./adhocracy4/static/api.js')
 }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   ratings: require('./adhocracy4/ratings/static/ratings/react_ratings.jsx'),
   comments: require('./adhocracy4/comments/static/comments/react_comments.jsx'),
   reports: require('./adhocracy4/reports/static/reports/react_reports.jsx'),
+  follows: require('./adhocracy4/reports/static/reports/react_follows.jsx'),
   config: require('./adhocracy4/static/config.js'),
   api: require('./adhocracy4/static/api.js')
 }

--- a/tests/follows/conftest.py
+++ b/tests/follows/conftest.py
@@ -1,0 +1,5 @@
+from pytest_factoryboy import register
+
+from tests.follows import factories as follow_factories
+
+register(follow_factories.FollowFactory)

--- a/tests/follows/factories.py
+++ b/tests/follows/factories.py
@@ -1,0 +1,13 @@
+import factory
+
+from adhocracy4.follows import models as follow_models
+from adhocracy4.test import factories as a4_factories
+
+
+class FollowFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = follow_models.Follow
+
+    creator = factory.SubFactory(a4_factories.UserFactory)
+    project = factory.SubFactory(a4_factories.ProjectFactory)

--- a/tests/follows/test_follow_api.py
+++ b/tests/follows/test_follow_api.py
@@ -1,0 +1,49 @@
+import pytest
+from django.core.urlresolvers import reverse
+from rest_framework import status
+
+from adhocracy4.follows import models as follow_models
+
+
+@pytest.mark.django_db
+def test_anonymous_user_has_no_follow(apiclient):
+    url = reverse('follows-list')
+    response = apiclient.get(url)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_user_list_follows(apiclient, follow):
+    url = reverse('follows-list')
+    apiclient.force_authenticate(user=follow.creator)
+    response = apiclient.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data[0]['project'] == follow.project.slug
+    assert response.data[0]['enabled'] is True
+
+
+@pytest.mark.django_db
+def test_user_add_follow(apiclient, project, user):
+    url = reverse('follows-detail', args=[project.slug])
+    apiclient.force_authenticate(user=user)
+    response = apiclient.put(url)
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.data['project'] == project.slug
+    follow = follow_models.Follow.objects.get(creator=user, project=project)
+    assert follow.enabled is True
+
+    response = apiclient.put(url, {'enabled': False}, format='json')
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_user_unfollow(apiclient, follow):
+    project = follow.project
+    user = follow.creator
+    url = reverse('follows-detail', kwargs={'project__slug': project.slug})
+    apiclient.force_authenticate(user=user)
+    response = apiclient.put(url, {'enabled': False}, format='json')
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['project'] == project.slug
+    follow = follow_models.Follow.objects.get(creator=user, project=project)
+    assert follow.enabled is False

--- a/tests/follows/test_follow_signals.py
+++ b/tests/follows/test_follow_signals.py
@@ -1,0 +1,23 @@
+import pytest
+
+from adhocracy4.follows import models
+from adhocracy4.follows.signals import autofollow_hook
+
+
+@pytest.mark.django_db
+def test_autofollow_hook(user, question_factory):
+
+    question = question_factory(creator=user)
+    autofollow_hook(question)
+    follow = models.Follow.objects.get(creator=user, project=question.project)
+    assert follow
+    assert follow.enabled
+
+    follow.enabled = False
+    follow.save()
+
+    question = question_factory(creator=user, module=question.module)
+    autofollow_hook(question)
+    follow = models.Follow.objects.get(creator=user, project=question.project)
+    assert follow
+    assert not follow.enabled

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = (
     'adhocracy4.reports.apps.ReportsConfig',
     'adhocracy4.comments.apps.CommentsConfig',
     'adhocracy4.maps.apps.MapsConfig',
+    'adhocracy4.follows.apps.FollowsConfig',
 
     # adhocrayc4 generic apps
     'adhocracy4.ratings.apps.RatingsConfig',

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -148,6 +148,7 @@ A4_RATEABLES = (('a4test_questions', 'question'), ('a4comments', 'comment'),)
 A4_REPORTABLES = (('a4test_questions', 'question'),)
 A4_COMMENTABLES = (('a4test_questions', 'question'),
                    ('a4comments', 'comment'),)
+A4_AUTO_FOLLOWABLES = (('a4comments', 'comment'),)
 
 # Rich text fields
 

--- a/tests/project/urls.py
+++ b/tests/project/urls.py
@@ -5,11 +5,13 @@ from rest_framework import routers
 
 from adhocracy4.api import routers as a4routers
 from adhocracy4.projects import urls as prj_urls
+from adhocracy4.follows.api import FollowViewSet
 from adhocracy4.ratings.api import RatingViewSet
 from adhocracy4.reports.api import ReportViewSet
 from adhocracy4.comments.api import CommentViewSet
 
 router = routers.DefaultRouter()
+router.register(r'follows', FollowViewSet, base_name='follows')
 router.register(r'reports', ReportViewSet, base_name='reports')
 
 ct_router = a4routers.ContentTypeDefaultRouter()


### PR DESCRIPTION
This ports the follows app from a4-opin to adhocracy4 core. There are some important things to note:

-   It is currently only possible to follow projects. In the future it might be a requirement to follow other things, e.g. items. It is not yet clear how this will work exactly. It will probably be implemented as a separate (but related) feature. We think that using generic foreign keys is overkill here.

-   The react component does not currently support the case where the user is not logged in. For now, the recommended bahvior in this case is not to show the component. See https://github.com/liqd/a4-opin/issues/629 and https://github.com/liqd/a4-opin/issues/627 for related issues in a4-opin.

-   There is some discussion as to whether the API of this feature should be changed. This pull request keeps the current API. The related issue https://github.com/liqd/a4-opin/issues/510 should be moved to this repository.

-   The API does not currently check project membership on private projects. The recommended way for this is to check membership when sending notifications. It might be a good idea to check it here though.

-   The HTML code may need to be adapted in order to be stylable in different projects.