### PR TITLE
Enable signals for inheriting projects.

### DIFF
--- a/adhocracy4/projects/signals.py
+++ b/adhocracy4/projects/signals.py
@@ -6,18 +6,21 @@ from adhocracy4.images import services
 from .models import Project
 
 
-@receiver(post_init, sender=Project)
+@receiver(post_init)
 def backup_image_path(sender, instance, **kwargs):
-    instance._current_image_file = instance.image
+    if issubclass(sender, Project):
+        instance._current_image_file = instance.image
 
 
-@receiver(post_save, sender=Project)
+@receiver(post_save)
 def delete_old_image(sender, instance, **kwargs):
-    if hasattr(instance, '_current_image_file'):
-        if instance._current_image_file != instance.image:
-            services.delete_images([instance._current_image_file])
+    if issubclass(sender, Project):
+        if hasattr(instance, '_current_image_file'):
+            if instance._current_image_file != instance.image:
+                services.delete_images([instance._current_image_file])
 
 
-@receiver(post_delete, sender=Project)
+@receiver(post_delete)
 def delete_images_for_project(sender, instance, **kwargs):
-    services.delete_images([instance.image])
+    if issubclass(sender, Project):
+        services.delete_images([instance.image])


### PR DESCRIPTION
Currently the signals are registered explicitely for the Project base model. In
meinBerlin we inherit from the base model to enable external projects and
bplans. As Django signals do not take inheritance into account when handling
signals, it is required to register signals without binding to a sender and
check if the senders type is a subclass of Project manually.

If, for example for performance reasons, a general signal receiver is not wanted in the core, we could add explicit signal handlers for two inherited project types we had to implement. 