### PR TITLE
Remove the category related field name.

### DIFF
--- a/adhocracy4/categories/models.py
+++ b/adhocracy4/categories/models.py
@@ -23,6 +23,7 @@ class Categorizable(models.Model):
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
+        related_name='+',
     )
 
     class Meta:

--- a/tests/apps/questions/migrations/0003_remove_related_set.py
+++ b/tests/apps/questions/migrations/0003_remove_related_set.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('a4test_questions', '0002_question_category'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='question',
+            name='category',
+            field=models.ForeignKey(blank=True, to='a4categories.Category', related_name='+', on_delete=django.db.models.deletion.SET_NULL, null=True),
+        ),
+    ]


### PR DESCRIPTION
If concrete categorizable Items in different apps have the same Modelname, the related field reference on the category clashes. (For example `budgeting.models.Proposal` and `kiezkasse.models.Proposal` would bost result in the same `Category.proposal_set`)
As there is no real usecase to get the related items of a specific type from a Category object i propose to remove the backwards field reference 