### PR TITLE
Add a paging aware filterset.

### DIFF
--- a/adhocracy4/filters/filters.py
+++ b/adhocracy4/filters/filters.py
@@ -2,7 +2,22 @@ import django_filters
 from django.http import QueryDict
 
 
-class DefaultsFilterSet(django_filters.FilterSet):
+class PagedFilterSet(django_filters.FilterSet):
+    """Removes page parameters from the query when applying filters."""
+    page_kwarg = 'page'
+
+    def __init__(self, data, *args, **kwargs):
+        if self.page_kwarg in data:
+            try:
+                data.pop(self.page_kwarg)
+            except AttributeError:
+                # Create a mutable copy
+                data = data.copy()
+                data.pop(self.page_kwarg)
+        return super().__init__(data=data, *args, **kwargs)
+
+
+class DefaultsFilterSet(PagedFilterSet):
     """Extend to define default filter values.
 
     Set the defaults attribute. E.g.:

--- a/adhocracy4/filters/filters.py
+++ b/adhocracy4/filters/filters.py
@@ -8,12 +8,9 @@ class PagedFilterSet(django_filters.FilterSet):
 
     def __init__(self, data, *args, **kwargs):
         if self.page_kwarg in data:
-            try:
-                data.pop(self.page_kwarg)
-            except AttributeError:
-                # Create a mutable copy
-                data = data.copy()
-                data.pop(self.page_kwarg)
+            # Create a mutable copy
+            data = data.copy()
+            del data[self.page_kwarg]
         return super().__init__(data=data, *args, **kwargs)
 
 

--- a/tests/filter/test_paged_filterset.py
+++ b/tests/filter/test_paged_filterset.py
@@ -1,0 +1,19 @@
+from tests.apps.questions import models as question_models
+
+from adhocracy4.filters.filters import PagedFilterSet
+
+
+class TextFilter(PagedFilterSet):
+
+    class Meta:
+        model = question_models.Question
+        fields = ['text']
+
+
+def test_page_clean_query(rf):
+    request = rf.get('/questions', {
+        'page': 1
+    })
+
+    filterset = TextFilter(data=request.GET, request=request)
+    assert 'page' not in filterset.data


### PR DESCRIPTION
By default FilterSets from django_filter are keeping every non filter
argument in the query string. This results a problem when paging is used
in addition to filters (see liqd/a4-meinberlin#403)
It is desired to reset the page to zero when applying a filter. This PR
introduces a PagedFilterSet which removes the page argument from the
query string.