### PR TITLE
Add overwriteable get_languages method to emails

### DIFF
--- a/adhocracy4/emails/__init__.py
+++ b/adhocracy4/emails/__init__.py
@@ -44,12 +44,15 @@ class EmailBase:
     def get_attachments(self):
         return []
 
+    def get_languages(self, receiver):
+        return [get_language(), self.fallback_language]
+
     @classmethod
     def send(cls, object, *args, **kwargs):
         return cls().dispatch(object, *args, **kwargs)
 
     def render(self, template_name, context):
-        languages = [get_language(), self.fallback_language]
+        languages = self.get_languages(context['receiver'])
         template = select_template([
             '{}.{}.email'.format(template_name, lang)
             for lang in languages

--- a/adhocracy4/emails/__init__.py
+++ b/adhocracy4/emails/__init__.py
@@ -112,22 +112,12 @@ class ExternalNotification(Email):
     def get_receivers(self):
         return [getattr(self.object, self.email_attr_name)]
 
-    def get_context(self):
-        context = super().get_context()
-        context['receiver'] = getattr(self.object, self.email_attr_name)
-        return context
-
 
 class UserNotification(Email):
     user_attr_name = 'creator'
 
     def get_receivers(self):
         return [getattr(self.object, self.user_attr_name)]
-
-    def get_context(self):
-        context = super().get_context()
-        context['receiver'] = getattr(self.object, self.user_attr_name)
-        return context
 
 
 class ModeratorNotification(Email):


### PR DESCRIPTION
To allow for translated emails the overwriteable `get_languages` method
is introduced. It gets the receiver as an attribute an may be
overwritten to send Emails according to (not yet available) user
settings.
Currently the currently set language is used, which is set from the
browsers language settings if the call results from a user request or
from `settings.LANGUAGE_CODE`.