### PR TITLE
update leaflet to 1.0.x

### DIFF
--- a/adhocracy4/maps/static/a4maps/map_choose_point.js
+++ b/adhocracy4/maps/static/a4maps/map_choose_point.js
@@ -35,19 +35,36 @@ function createMarker ($, L, newlatln, oldlatln, basePolygon, map, name) {
   return marker
 }
 
+function * getLines (array) {
+  if (array.length) {
+    if ('lat' in array[0]) {
+      for (let i = 0, j = array.length - 1; i < array.length; j = i++) {
+        yield [array[i], array[j]]
+      }
+    } else {
+      for (let a of array) {
+        for (let line of getLines(a)) {
+          yield line
+        }
+      }
+    }
+  }
+}
+
 function isMarkerInsidePolygon (marker, poly) {
-  var polyPoints = poly.getLatLngs()
   var x = marker.getLatLng().lat
   var y = marker.getLatLng().lng
 
   // Algorithm comes from:
   // https://github.com/substack/point-in-polygon/blob/master/index.js
   var inside = false
-  for (var i = 0, j = polyPoints.length - 1; i < polyPoints.length; j = i++) {
-    var xi = polyPoints[i].lat
-    var yi = polyPoints[i].lng
-    var xj = polyPoints[j].lat
-    var yj = polyPoints[j].lng
+
+  // FIXME: getLatLngs does not return holes. Maybe use toGetJson instead?
+  for (let line of getLines(poly.getLatLngs())) {
+    var xi = line[0].lat
+    var yi = line[0].lng
+    var xj = line[1].lat
+    var yj = line[1].lng
 
     //      *
     //     /

--- a/adhocracy4/maps/static/a4maps/map_choose_point.js
+++ b/adhocracy4/maps/static/a4maps/map_choose_point.js
@@ -85,7 +85,7 @@ var init = function () {
     }
 
     var basePolygon = L.geoJson(polygon, {style: polygonStyle}).addTo(map)
-    map.fitBounds(basePolygon)
+    map.fitBounds(basePolygon.getBounds())
     map.options.minZoom = map.getZoom()
     L.control.zoom({
       position: 'topleft'

--- a/adhocracy4/maps/static/a4maps/map_choose_polygon.js
+++ b/adhocracy4/maps/static/a4maps/map_choose_polygon.js
@@ -43,13 +43,13 @@ var init = function () {
         style: polygonStyle
       })
       if (drawnItems.getLayers().length > 0) {
-        map.fitBounds(drawnItems)
+        map.fitBounds(drawnItems.getBounds())
       } else {
-        map.fitBounds(getBasePolygon(L, polygon, bbox))
+        map.fitBounds(getBasePolygon(L, polygon, bbox).getBounds())
       }
     } else {
       drawnItems = L.featureGroup()
-      map.fitBounds(getBasePolygon(L, polygon, bbox))
+      map.fitBounds(getBasePolygon(L, polygon, bbox).getBounds())
     }
     drawnItems.addTo(map)
 
@@ -93,7 +93,7 @@ var init = function () {
     })
 
     $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-      map.invalidateSize().fitBounds(getBasePolygon(L, polygon, bbox))
+      map.invalidateSize().fitBounds(getBasePolygon(L, polygon, bbox).getBounds())
     })
   })
 }

--- a/adhocracy4/maps/static/a4maps/map_display_point.js
+++ b/adhocracy4/maps/static/a4maps/map_display_point.js
@@ -31,7 +31,7 @@ var init = function () {
     })
 
     var basePolygon = L.geoJson(polygon, {style: polygonStyle}).addTo(map)
-    map.fitBounds(basePolygon)
+    map.fitBounds(basePolygon.getBounds())
     map.options.minZoom = map.getZoom()
     L.control.zoom({
       position: 'topleft'

--- a/adhocracy4/maps/static/a4maps/map_display_points.js
+++ b/adhocracy4/maps/static/a4maps/map_display_points.js
@@ -43,7 +43,7 @@ var init = function () {
       map.closePopup()
     })
 
-    map.fitBounds(basePolygon)
+    map.fitBounds(basePolygon.getBounds())
     map.options.minZoom = map.getZoom()
     initial = 1
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react": "15.1.0",
     "react-addons-update": "~15.1.0",
     "react-dom": "15.1.0",
-    "leaflet": "^0.7.7",
+    "leaflet": "^1.0.3",
     "leaflet-draw": "^0.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md

This updates leaflet to 1.0.3. All changes I made should be backwards compatible.

I testes all four map types and found no further issues. leaflet.draw also seemed to work fine with the new version.

I encountered on strange issue: Yesterday, when ever I was on a page that had leaflet loaded, I was unable to scroll the page. However, today I could not reprodce the issue anymore.

See also https://github.com/liqd/a4-meinberlin/pull/544 for further changes that might be required for individual platforms.