### PR TITLE
Add START verb and signal start of projects

### DIFF
--- a/adhocracy4/actions/management/commands/create_system_actions.py
+++ b/adhocracy4/actions/management/commands/create_system_actions.py
@@ -1,8 +1,11 @@
+from datetime import timedelta
 from django.core.management.base import BaseCommand
+from django.contrib.contenttypes.models import ContentType
 
-from adhocracy4.phases.models import Phase
 from adhocracy4.actions.models import Action
 from adhocracy4.actions.verbs import Verbs
+from adhocracy4.phases.models import Phase
+from adhocracy4.projects.models import Project
 
 
 class Command(BaseCommand):
@@ -10,22 +13,58 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self._phase_end_tomorrow()
+        self._project_start_last_hour()
 
     def _phase_end_tomorrow(self):
-        phases = Phase.objects.finish_next()
+        phase_ct = ContentType.objects.get_for_model(Phase)
 
+        phases = Phase.objects.finish_next(hours=24)
         for phase in phases:
             project = phase.module.project
             existing_action = Action.objects.filter(
                 project=project,
                 verb=Verbs.SCHEDULE.value,
-                timestamp=phase.end_date,
-            )
+                obj_content_type=phase_ct,
+                obj_object_id=phase.id
+            ).first()
 
-            if not existing_action:
+            # The existing action may be from the past, as it could be possible
+            # that someone modified the phases end date. In that case a new end
+            # of phase schedule action is created
+            if not existing_action \
+                or (existing_action.timestamp + timedelta(hours=24)) \
+                    < phase.end_date:
+
                 Action.objects.create(
                     project=project,
                     verb=Verbs.SCHEDULE.value,
-                    timestamp=phase.end_date,
                     obj=phase,
                 )
+
+    def _project_start_last_hour(self):
+        project_ct = ContentType.objects.get_for_model(Project)
+
+        phases = Phase.objects.start_next(hours=1)
+        for phase in phases:
+            project = phase.module.project
+            first_phase = project.phases.first()
+            if phase == first_phase:
+                existing_action = Action.objects.filter(
+                    project=project,
+                    verb=Verbs.START.value,
+                    obj_content_type=project_ct,
+                    obj_object_id=project.id
+                ).first()
+
+                # The existing action may be from the past, as it could be
+                # possible that someone modified the phases start date.
+                # In that case a new project start action ist created
+                if not existing_action \
+                    or (existing_action.timestamp + timedelta(hours=1)) \
+                        < phase.start_date:
+
+                    Action.objects.create(
+                        project=project,
+                        verb=Verbs.START.value,
+                        obj=project,
+                    )

--- a/adhocracy4/actions/migrations/0002_add_START_verb.py
+++ b/adhocracy4/actions/migrations/0002_add_START_verb.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('a4actions', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='action',
+            name='verb',
+            field=models.CharField(max_length=255, choices=[('create', 'CREATE'), ('add', 'ADD'), ('update', 'UPDATE'), ('complete', 'COMPLETE'), ('schedule', 'SCHEDULE'), ('start', 'START')], db_index=True),
+        ),
+    ]

--- a/adhocracy4/actions/signals.py
+++ b/adhocracy4/actions/signals.py
@@ -35,6 +35,7 @@ def add_action(sender, instance, created, **kwargs):
         target=target,
     )
 
+    # TODO: this could be extended
     if hasattr(instance, 'project'):
         action.project = instance.project
 

--- a/adhocracy4/actions/verbs.py
+++ b/adhocracy4/actions/verbs.py
@@ -8,6 +8,7 @@ class Verbs(enum.Enum):
     UPDATE = 'update'
     COMPLETE = 'complete'
     SCHEDULE = 'schedule'
+    START = 'start'
 
 
 def choices():

--- a/adhocracy4/phases/models.py
+++ b/adhocracy4/phases/models.py
@@ -20,13 +20,22 @@ class PhasesQuerySet(models.QuerySet):
     def finished_phases(self):
         return self.filter(end_date__lte=timezone.now())
 
-    def finish_next(self):
+    def finish_next(self, hours=24):
         """
-        All phases that are active and finish within 24 hours.
+        All phases that are active and finish within the given time.
         """
         now = timezone.now()
-        tomorrow = (now + timedelta(days=1))
-        return self.active_phases().filter(end_date__lte=tomorrow)
+        last_end_date = (now + timedelta(hours=hours))
+        return self.active_phases().filter(end_date__lte=last_end_date)
+
+    def start_next(self, hours=1):
+        """
+        All phases that will start within the given time.
+        """
+        now = timezone.now()
+        last_start_date = (now + timedelta(hours=hours))
+        return self.filter(start_date__gt=now, start_date__lt=last_start_date)
+
 
 
 class Phase(models.Model):

--- a/adhocracy4/phases/models.py
+++ b/adhocracy4/phases/models.py
@@ -28,14 +28,13 @@ class PhasesQuerySet(models.QuerySet):
         last_end_date = (now + timedelta(hours=hours))
         return self.active_phases().filter(end_date__lte=last_end_date)
 
-    def start_next(self, hours=1):
+    def start_last(self, hours=1):
         """
-        All phases that will start within the given time.
+        All phases that have started within the given time.
         """
         now = timezone.now()
-        last_start_date = (now + timedelta(hours=hours))
-        return self.filter(start_date__gt=now, start_date__lt=last_start_date)
-
+        first_start_date = (now - timedelta(hours=hours))
+        return self.filter(start_date__gt=first_start_date, start_date__lt=now)
 
 
 class Phase(models.Model):
@@ -80,3 +79,7 @@ class Phase(models.Model):
 
     def has_feature(self, feature, model):
         return content[self.type].has_feature(feature, model)
+
+    def is_first_of_project(self):
+        """Test if this is the first phase of the project."""
+        return self == self.module.project.phases.first()

--- a/tests/actions/test_commands.py
+++ b/tests/actions/test_commands.py
@@ -8,6 +8,9 @@ from freezegun import freeze_time
 from adhocracy4.actions.models import Action
 from adhocracy4.actions.verbs import Verbs
 
+SCHEDULE = Verbs.SCHEDULE.value
+START = Verbs.START.value
+
 
 @pytest.mark.django_db
 def test_phase_end_later(phase_factory):
@@ -19,7 +22,7 @@ def test_phase_end_later(phase_factory):
 
     with freeze_time('2013-01-01 00:00:00 UTC'):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
+        action_count = Action.objects.filter(verb=SCHEDULE).count()
         assert action_count == 0
 
 
@@ -33,16 +36,16 @@ def test_phase_end_tomorrow(phase_factory):
 
     project = phase.module.project
 
-    action_count = Action.objects.all().count()
+    action_count = Action.objects.filter(verb=SCHEDULE).count()
     assert action_count == 0
 
     with freeze_time('2013-01-01 17:30:00 UTC'):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
-        action = Action.objects.last()
+        action_count = Action.objects.filter(verb=SCHEDULE).count()
+        action = Action.objects.filter(verb=SCHEDULE).last()
         assert action_count == 1
         assert action.obj == phase
-        assert action.verb == Verbs.SCHEDULE.value
+        assert action.verb == SCHEDULE
         assert action.project == project
 
 
@@ -69,25 +72,25 @@ def test_next_phase_end_tomorrow(phase_factory):
     # first phase ends within 24 h
     with freeze_time(phase1.end_date - timedelta(hours=1)):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
+        action_count = Action.objects.filter(verb=SCHEDULE).count()
         assert action_count == 1
 
     # second phase ends within 24 h
     with freeze_time(phase2.end_date - timedelta(hours=1)):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
+        action_count = Action.objects.filter(verb=SCHEDULE).count()
         assert action_count == 2
 
     # second phase ends within 24 h but script has already run
     with freeze_time(phase2.end_date - timedelta(hours=1)):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
+        action_count = Action.objects.filter(verb=SCHEDULE).count()
         assert action_count == 2
 
     # third phase ends within 24 h but script has already run
     with freeze_time(phase3.start_date):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
+        action_count = Action.objects.filter(verb=SCHEDULE).count()
         assert action_count == 3
 
 
@@ -102,7 +105,7 @@ def test_phase_reschedule(phase_factory):
     # first phase ends within 24 h
     with freeze_time(phase.end_date - timedelta(hours=1)):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
+        action_count = Action.objects.filter(verb=SCHEDULE).count()
         assert action_count == 1
 
     # first phases end date has been moved forward
@@ -111,12 +114,12 @@ def test_phase_reschedule(phase_factory):
     phase.save()
     with freeze_time(phase.end_date - timedelta(hours=1)):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
+        action_count = Action.objects.filter(verb=SCHEDULE).count()
         assert action_count == 2
 
 
 @pytest.mark.django_db
-def test_project_starts_later(phase_factory):
+def test_project_starts_later_or_earlier(phase_factory):
 
     phase = phase_factory(
         start_date=parse('2013-01-01 17:00:00 UTC'),
@@ -125,7 +128,12 @@ def test_project_starts_later(phase_factory):
 
     with freeze_time(phase.start_date - timedelta(days=1)):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
+        action_count = Action.objects.filter(verb=START).count()
+        assert action_count == 0
+
+    with freeze_time(phase.start_date + timedelta(days=1)):
+        call_command('create_system_actions')
+        action_count = Action.objects.filter(verb=START).count()
         assert action_count == 0
 
 
@@ -145,24 +153,24 @@ def test_project_start_hour(phase_factory):
 
     project = phase.module.project
 
-    action_count = Action.objects.all().count()
+    action_count = Action.objects.filter(verb=START).count()
     assert action_count == 0
 
-    with freeze_time(phase.start_date - timedelta(minutes=30)):
+    with freeze_time(phase.start_date + timedelta(minutes=30)):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
-        action = Action.objects.last()
+        action_count = Action.objects.filter(verb=START).count()
+        action = Action.objects.filter(verb=START).last()
         assert action_count == 1
         assert action.obj == project
-        assert action.verb == Verbs.START.value
+        assert action.verb == START
         assert action.project == project
 
-    # second phase starts within an hour,
+    # second phase starts within the last hour,
     # but that may not trigger a project start action
-    with freeze_time(phase2.start_date - timedelta(minutes=30)):
+    with freeze_time(phase2.start_date + timedelta(minutes=30)):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
-        action = Action.objects.last()
+        action_count = Action.objects.filter(verb=START).count()
+        action = Action.objects.filter(verb=START).last()
         assert action_count == 1
 
 
@@ -174,18 +182,18 @@ def test_project_start_single_action(phase_factory):
         end_date=parse('2013-01-01 18:00:00 UTC')
     )
 
-    action_count = Action.objects.all().count()
+    action_count = Action.objects.filter(verb=START).count()
     assert action_count == 0
 
-    with freeze_time(phase.start_date - timedelta(minutes=30)):
+    with freeze_time(phase.start_date + timedelta(minutes=30)):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
+        action_count = Action.objects.filter(verb=START).count()
         assert action_count == 1
 
-    # first phase starts within an hour but script has already run
-    with freeze_time(phase.start_date - timedelta(minutes=30)):
+    # first phase starts within the last hour but script has already run
+    with freeze_time(phase.start_date + timedelta(minutes=45)):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
+        action_count = Action.objects.filter(verb=START).count()
         assert action_count == 1
 
 
@@ -198,16 +206,16 @@ def test_project_start_reschedule(phase_factory):
     )
 
     # first phase starts within an hour
-    with freeze_time(phase.start_date - timedelta(minutes=30)):
+    with freeze_time(phase.start_date + timedelta(minutes=30)):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
+        action_count = Action.objects.filter(verb=START).count()
         assert action_count == 1
 
     # first phases start date has been moved forward
     # and a new action will be created
     phase.start_date = phase.start_date + timedelta(days=1)
     phase.save()
-    with freeze_time(phase.start_date - timedelta(minutes=30)):
+    with freeze_time(phase.start_date + timedelta(minutes=30)):
         call_command('create_system_actions')
-        action_count = Action.objects.all().count()
+        action_count = Action.objects.filter(verb=START).count()
         assert action_count == 2


### PR DESCRIPTION
The start of a project ist defined with an Action with the verb START
and the project as the object.
A START action will be created if a project first phase starts within
the next hour.