### PR TITLE
Delete Actions if the related object is deleted

### DIFF
--- a/adhocracy4/actions/signals.py
+++ b/adhocracy4/actions/signals.py
@@ -7,7 +7,7 @@ from django.db.models.signals import post_delete, post_save
 from .models import Action
 from .verbs import Verbs
 
-
+# Actions resulting from the create_system_actions management call
 SYSTEM_ACTIONABLES = (
     ('a4phases', 'Phase'),
     ('a4projects', 'Project')

--- a/adhocracy4/actions/signals.py
+++ b/adhocracy4/actions/signals.py
@@ -1,9 +1,17 @@
+from itertools import chain
 from django.apps import apps
 from django.conf import settings
-from django.db.models.signals import post_save
+from django.contrib.contenttypes.models import ContentType
+from django.db.models.signals import post_delete, post_save
 
 from .models import Action
 from .verbs import Verbs
+
+
+SYSTEM_ACTIONABLES = (
+    ('a4phases', 'Phase'),
+    ('a4projects', 'Project')
+)
 
 
 def _extract_target(instance):
@@ -15,7 +23,7 @@ def _extract_target(instance):
     return target
 
 
-def add_action(sender, instance, created, **kwargs):
+def _add_action(sender, instance, created, **kwargs):
     actor = instance.creator if hasattr(instance, 'creator') else None
     target = None
     if created:
@@ -42,4 +50,15 @@ def add_action(sender, instance, created, **kwargs):
 
 
 for app, model in settings.A4_ACTIONABLES:
-    post_save.connect(add_action, apps.get_model(app, model))
+    post_save.connect(_add_action, apps.get_model(app, model))
+
+
+def _delete_action(sender, instance, **kwargs):
+    contenttype = ContentType.objects.get_for_model(sender)
+    Action.objects\
+        .filter(obj_content_type=contenttype, obj_object_id=instance.id)\
+        .delete()
+
+
+for app, model in chain(SYSTEM_ACTIONABLES, settings.A4_ACTIONABLES):
+    post_delete.connect(_delete_action, apps.get_model(app, model))

--- a/tests/actions/test_signals.py
+++ b/tests/actions/test_signals.py
@@ -1,14 +1,14 @@
 import pytest
 
 from adhocracy4.actions.models import Action
-from adhocracy4.actions.signals import add_action
+from adhocracy4.actions.signals import _add_action, _delete_action
 from adhocracy4.actions.verbs import Verbs
 
 
 @pytest.mark.django_db
 def test_project_create(project_factory):
     project = project_factory()
-    add_action(None, project, True)
+    _add_action(None, project, True)
     action = Action.objects.first()
     assert action.actor is None
     assert action.obj == project
@@ -19,7 +19,7 @@ def test_project_create(project_factory):
 @pytest.mark.django_db
 def test_item_add(question_factory):
     question = question_factory()
-    add_action(None, question, True)
+    _add_action(None, question, True)
     action = Action.objects.last()
     assert action.actor == question.creator
     assert action.obj == question
@@ -31,7 +31,7 @@ def test_item_add(question_factory):
 @pytest.mark.django_db
 def test_item_update(question_factory):
     question = question_factory()
-    add_action(None, question, False)
+    _add_action(None, question, False)
     action = Action.objects.last()
     assert action.actor == question.creator
     assert action.obj == question
@@ -41,10 +41,18 @@ def test_item_update(question_factory):
 
 
 @pytest.mark.django_db
+def test_item_delete(question_factory):
+    question = question_factory()
+    _add_action(question_factory._meta.model, question, False)
+    _delete_action(question_factory._meta.model, question)
+    assert Action.objects.all().count() == 0
+
+
+@pytest.mark.django_db
 def test_content_object_create(question_factory, comment_factory):
     question = question_factory()
     comment = comment_factory(content_object=question)
-    add_action(None, comment, True)
+    _add_action(None, comment, True)
     action = Action.objects.last()
     assert action.actor == comment.creator
     assert action.obj == comment
@@ -57,7 +65,7 @@ def test_content_object_create(question_factory, comment_factory):
 def test_content_object_update(question_factory, comment_factory):
     question = question_factory()
     comment = comment_factory(content_object=question)
-    add_action(None, comment, False)
+    _add_action(None, comment, False)
     action = Action.objects.last()
     assert action.actor == comment.creator
     assert action.obj == comment


### PR DESCRIPTION
As we are loosing all the information when the object of an action is
deleted, the action itself may be deleted, too.