### PR TITLE
Set the START project actions timestamp to the actual phases start_date

### DIFF
--- a/adhocracy4/actions/management/commands/create_system_actions.py
+++ b/adhocracy4/actions/management/commands/create_system_actions.py
@@ -54,13 +54,17 @@ class Command(BaseCommand):
                     obj_object_id=project.id
                 ).first()
 
-                # If the first phases start has been modified and moved ahead
-                # of the previous action, a new project start action is created
-                if not existing_action \
-                        or existing_action.timestamp < phase.start_date:
-
+                if not existing_action:
                     Action.objects.create(
                         project=project,
                         verb=Verbs.START.value,
                         obj=project,
+                        timestamp=phase.start_date
                     )
+
+                elif existing_action.timestamp < phase.start_date:
+                    # If the first phases start has been modified and moved
+                    # ahead, the existing actions timestamp has be adapted to
+                    # the actual project start.
+                    existing_action.timestamp = phase.start_date
+                    existing_action.save()

--- a/tests/actions/test_commands.py
+++ b/tests/actions/test_commands.py
@@ -138,7 +138,7 @@ def test_project_starts_later_or_earlier(phase_factory):
 
 
 @pytest.mark.django_db
-def test_project_start_hour(phase_factory):
+def test_project_start_last_hour(phase_factory):
 
     phase = phase_factory(
         start_date=parse('2013-01-01 17:00:00 UTC'),
@@ -212,10 +212,12 @@ def test_project_start_reschedule(phase_factory):
         assert action_count == 1
 
     # first phases start date has been moved forward
-    # and a new action will be created
+    # and the start actions timestamp has to be adapted
     phase.start_date = phase.start_date + timedelta(days=1)
     phase.save()
     with freeze_time(phase.start_date + timedelta(minutes=30)):
         call_command('create_system_actions')
         action_count = Action.objects.filter(verb=START).count()
-        assert action_count == 2
+        assert action_count == 1
+        action = Action.objects.filter(verb=START).first()
+        assert action.timestamp == phase.start_date


### PR DESCRIPTION
The START action should include the actual objects start timestamp. If a project start is rescheduled the original START action has to be adapted.

This is different from the SCHEDULE action, where the timestamp is in relation to the action itself.
In opin the SCHEDULE action is not used to send the "ends in 24 hours/soon" email, but a COMPLETE action which is not in a4 core yet.
While i agree to use  the phase.end_date as the timestamp for the COMPLETE action, i'd argue to keep the time when the action was created as the timestamp for the SCHEDULE action.

@xi @slomo  what is your opinion on

The START action and the modifications to SCHEDULE were initially introduces in #108 