### PR TITLE
Add eslint plugin dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "eslint-plugin-promise": "^3.0.0",
     "eslint-plugin-react": "^7.1.0",
     "eslint-plugin-standard": "^3.0.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-node": "^4.2.2",
     "husky": "0.13.4",
     "polylint.sh": "0.0.2"
   },


### PR DESCRIPTION
Before a warning was emitted on `node install`:
```
npm WARN eslint-config-standard@10.2.1 requires a peer of eslint-plugin-import@>=2.2.0 but none was installed.
npm WARN eslint-config-standard@10.2.1 requires a peer of eslint-plugin-node@>=4.2.2 but none was installed.
```

and linting failed with:
```
⌂ ~/g/adhocracy4 » make lint                                                                                                                                                             2017-06-as-async-emails ✗
. ./bin/activate && node_modules/.bin/polylint
node_modules/.bin/polylint: 1: eval: flake8: not found

Oops! Something went wrong! :(

ESLint couldn't find the plugin "eslint-plugin-import". This can happen for a couple different reasons:

1. If ESLint is installed globally, then make sure eslint-plugin-import is also installed globally. A globally-installed ESLint cannot find a locally-installed plugin.

2. If ESLint is installed locally, then it's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm i eslint-plugin-import@latest --save-dev

If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.

Makefile:21: recipe for target 'lint' failed
make: *** [lint] Error 1
```