### PR TITLE
overwrite polygon default help text

### DIFF
--- a/adhocracy4/maps/migrations/0002_change_help_text.py
+++ b/adhocracy4/maps/migrations/0002_change_help_text.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import adhocracy4.maps.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('a4maps', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='areasettings',
+            name='polygon',
+            field=adhocracy4.maps.fields.MultiPolygonField(help_text='Please draw an area on the map.', verbose_name='Polygon'),
+        ),
+    ]

--- a/adhocracy4/maps/models.py
+++ b/adhocracy4/maps/models.py
@@ -1,3 +1,5 @@
+from django.utils.translation import ugettext_lazy as _
+
 from adhocracy4.modules import models as module_models
 
 from .fields import MultiPolygonField
@@ -5,7 +7,10 @@ from .widgets import MapChoosePolygonWidget
 
 
 class AreaSettings(module_models.AbstractSettings):
-    polygon = MultiPolygonField()
+    polygon = MultiPolygonField(
+        verbose_name=_('Polygon'),
+        help_text=_('Please draw an area on the map.')
+    )
 
     @staticmethod
     def widgets():


### PR DESCRIPTION
the default help text is "enter valid JSON". It can not be blank (see https://github.com/dmkoch/django-jsonfield/issues/95)

see also https://github.com/liqd/a4-meinberlin/issues/503