### PR TITLE
Allow to override kwargs in FilteredListViews

### DIFF
--- a/adhocracy4/filters/filters.py
+++ b/adhocracy4/filters/filters.py
@@ -25,8 +25,8 @@ class DefaultsFilterSet(PagedFilterSet):
 
     defaults = None
 
-    def __init__(self, query_data, *args, **kwargs):
-        data = query_data.copy()
+    def __init__(self, data, *args, **kwargs):
+        data = data.copy()
 
         # Set the defaults if they are not manually set yet
         for key, value in self.defaults.items():

--- a/adhocracy4/filters/views.py
+++ b/adhocracy4/filters/views.py
@@ -15,10 +15,18 @@ class FilteredListView(generic.ListView):
 
     filter_set = None
 
+    def filter_kwargs(self):
+        default_kwargs = {
+            'data': self.request.GET,
+            'request': self.request,
+            'queryset': super().get_queryset()
+        }
+
+        return default_kwargs
+
     def filter(self):
         return self.filter_set(
-            self.request.GET,
-            request=self.request
+            **self.filter_kwargs()
         )
 
     def get_queryset(self):


### PR DESCRIPTION
 - passes the queryset from the list view to the filter instead of the filter using `$model.objects.all()`
    - allows to prefilter the queryset with the `queryset` option of the view.
 - allows to pass additional arguments to the FilterSet initializer from views extending the FilteredListViews
    - use case was to filter ideas on a profile based on which users profile I am currently viewing

I am pretty confident that the first feature should not make any issues, but still marking this breaking.