### PR TITLE
fix getBasePolygon

### DIFF
--- a/adhocracy4/maps/static/a4maps/map_choose_polygon.js
+++ b/adhocracy4/maps/static/a4maps/map_choose_polygon.js
@@ -6,12 +6,12 @@ function createMap (L, baseurl, attribution, e) {
   return map
 }
 
-function getBasePolygon (L, polygon, bbox) {
+function getBaseBounds (L, polygon, bbox) {
   if (polygon) {
     if (polygon.type === 'FeatureCollection' && polygon.features.length === 0) {
       return bbox
     }
-    return L.geoJson(polygon)
+    return L.geoJson(polygon).getBounds()
   } else {
     return bbox
   }
@@ -45,11 +45,11 @@ var init = function () {
       if (drawnItems.getLayers().length > 0) {
         map.fitBounds(drawnItems.getBounds())
       } else {
-        map.fitBounds(getBasePolygon(L, polygon, bbox).getBounds())
+        map.fitBounds(getBaseBounds(L, polygon, bbox))
       }
     } else {
       drawnItems = L.featureGroup()
-      map.fitBounds(getBasePolygon(L, polygon, bbox).getBounds())
+      map.fitBounds(getBaseBounds(L, polygon, bbox))
     }
     drawnItems.addTo(map)
 
@@ -93,7 +93,7 @@ var init = function () {
     })
 
     $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-      map.invalidateSize().fitBounds(getBasePolygon(L, polygon, bbox).getBounds())
+      map.invalidateSize().fitBounds(getBaseBounds(L, polygon, bbox))
     })
   })
 }


### PR DESCRIPTION
fixup to #107

If polygon was undefined (e.g. when creating a new project) bbox was used. bbox is not a polygon.

The issue is fixed by returning bounds directly.

See also https://github.com/liqd/a4-meinberlin/pull/544/commits/895ab6aa55fb33192d729f8be7aeeaaae9af007c