### PR TITLE
Extend actions properties and queryset

### DIFF
--- a/adhocracy4/actions/migrations/0003_set_default_ordering_to_timestamp.py
+++ b/adhocracy4/actions/migrations/0003_set_default_ordering_to_timestamp.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('a4actions', '0002_add_START_verb'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='action',
+            options={'ordering': ('-timestamp',)},
+        ),
+    ]

--- a/tests/actions/conftest.py
+++ b/tests/actions/conftest.py
@@ -2,4 +2,7 @@ from pytest_factoryboy import register
 
 from tests.comments import factories as comments_factories
 
+from tests.actions import factories
+
 register(comments_factories.CommentFactory)
+register(factories.ActionFactory)

--- a/tests/actions/factories.py
+++ b/tests/actions/factories.py
@@ -1,0 +1,24 @@
+import factory
+
+from django.conf import settings
+
+from adhocracy4.actions import models, verbs
+from adhocracy4.test.factories import UserFactory
+
+from tests.apps.questions.factories import QuestionFactory
+
+
+USER_FACTORY = getattr(settings, 'A4_USER_FACTORY', UserFactory)
+
+
+class ActionFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.Action
+    verb = verbs.Verbs.ADD.value
+    actor = factory.SubFactory(USER_FACTORY)
+    obj = factory.SubFactory(QuestionFactory)
+
+    @factory.post_generation
+    def project(obj, create, extracted, **kwargs):
+        if obj.obj:
+            obj.project = obj.obj.project


### PR DESCRIPTION
-  extend queryset with `exlude_update` and `filter_public` (used in mB and AE)
- make type and icon properties of Action (removes need for Proxy model)
   -  allow each project to configure its icons and types
- change default ordering to descending by creation time

Example usage: https://github.com/liqd/a4-advocate-europe/pull/187