### PR TITLE
Fix image validation

### DIFF
--- a/adhocracy4/images/validators.py
+++ b/adhocracy4/images/validators.py
@@ -21,7 +21,7 @@ def validate_image(
                 ', '.join(fileformats)
             )
         )
-        errors.append(ValidationError(msg))
+        raise ValidationError(msg)
     if image.size > max_size:
         max_size_mb = math.floor(max_size/10**6)
         msg = _('Image should be at most {max_size} MB')


### PR DESCRIPTION
Fixes https://github.com/liqd/a4-meinberlin/issues/616

Validation of SVG images failes on `image.width`, as it does not have a width.

Raising directly, if the image format is not supported.