### PR TITLE
update react: fix IE11 incompatibility

### DIFF
--- a/adhocracy4/comments/static/comments/CommentBox.jsx
+++ b/adhocracy4/comments/static/comments/CommentBox.jsx
@@ -3,7 +3,7 @@ var CommentForm = require('./CommentForm')
 var api = require('../../../static/api')
 
 var React = require('react')
-var update = require('react-addons-update')
+var update = require('immutability-helper')
 var django = require('django')
 
 let CommentBox = React.createClass({

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "leaflet": "^0.7.7",
     "leaflet-draw": "^0.4.2",
     "moment": "^2.14.1",
-    "react": "15.1.0",
-    "react-addons-update": "~15.1.0",
-    "react-dom": "15.1.0",
+    "react": "15.6.1",
+    "immutability-helper": "^2.3.0",
+    "react-dom": "15.6.1",
     "leaflet": "^1.0.3",
     "leaflet-draw": "^0.4.2"
   },


### PR DESCRIPTION
The react version (or rather react-addons-update) we are currently using relies on `Object.assign` to be native. IE11 obviously has that not implemented and breaks. 

This PR updates react (https://github.com/facebook/react/pull/9932) and introduces a dependency called ['immutability-helper'](https://github.com/kolodny/immutability-helper) which replaces the deprecated 'react-addons-update. 

Wherever you use that dependency you simply have to replace it:
```js
// var update = require('react-addons-update')
var update = require('immutability-helper')
```
E.g. here: https://github.com/liqd/a4-opin/blob/06bb71e02caf83f2f7057a4cc7e51c35ec18bee1/euth/documents/static/documents/ParagraphBox.jsx#L5

Advocate Europe does not seem to use that one (yet).