### PR TITLE
remove moment

### DIFF
--- a/adhocracy4/comments/static/comments/Comment.jsx
+++ b/adhocracy4/comments/static/comments/Comment.jsx
@@ -8,10 +8,13 @@ var CommentManageDropdown = require('./CommentManageDropdown')
 
 var React = require('react')
 var django = require('django')
-var moment = require('moment')
 
 var safeHtml = function (text) {
   return { __html: text }
+}
+
+var localeDate = function (dateStr) {
+  return new Date(dateStr).toLocaleString(document.documentElement.lang)
 }
 
 var Comment = React.createClass({
@@ -102,9 +105,9 @@ var Comment = React.createClass({
     let CommentList = require('./CommentList')
     let lastDate
     if (this.props.modified === null && !this.props.is_deleted) {
-      lastDate = moment(this.props.created).format('lll')
+      lastDate = localeDate(this.props.created)
     } else if (!this.props.is_deleted) {
-      lastDate = django.gettext('Latest edit on') + ' ' + moment(this.props.modified).format('lll')
+      lastDate = django.gettext('Latest edit on') + ' ' + localeDate(this.props.modified)
     }
 
     let moderatorLabel

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "classnames": "^2.2.5",
     "jquery": "2.2.4",
     "js-cookie": "~2.1.2",
-    "moment": "^2.14.1",
     "react": "15.6.1",
     "immutability-helper": "^2.3.0",
     "react-dom": "15.6.1",


### PR DESCRIPTION
This allows us to dump moment.js. 

This is not breaking, but I still suggest to remove lines located in webpack.config (e.g. https://github.com/liqd/a4-opin/blob/ae114fc8c5bd010dec9b0736f5dd316cd5932bb7/webpack.config.js#L37) or package.json.