### PR TITLE
Fix has_feature_active in case module is not really a module

### DIFF
--- a/adhocracy4/phases/predicates.py
+++ b/adhocracy4/phases/predicates.py
@@ -2,6 +2,7 @@ import rules
 
 
 def has_feature_active(module, model, feature):
+    module = getattr(module, 'module', module)
     if not module.active_phase:
         return False
     else:


### PR DESCRIPTION
This fixes a regression introduced in #153.

This workaround works for me. @kleingeist can you please try to find a proper fix?