### PR TITLE
ui to explain follow

### DIFF
--- a/adhocracy4/follows/static/follows/FollowButton.jsx
+++ b/adhocracy4/follows/static/follows/FollowButton.jsx
@@ -11,14 +11,24 @@ class FollowButton extends React.Component {
       follows: 0
     }
   }
-  toggleFollow () {
-    api.follow.change({ enabled: !this.state.followed }, this.props.project)
+  setFollow (enabled) {
+    if (enabled === this.state.followed) {
+      return false
+    }
+
+    api.follow.change({ enabled: enabled }, this.props.project)
       .done((follow) => {
         this.setState({
           followed: follow.enabled,
           follows: follow.follows
         })
       })
+  }
+  enableFollow () {
+    this.setFollow(true)
+  }
+  disableFollow () {
+    this.setFollow(false)
   }
   componentDidMount () {
     api.follow.get(this.props.project)
@@ -46,14 +56,14 @@ class FollowButton extends React.Component {
             <i className="fa fa-caret-down" aria-hidden="true" />
           </button>
           <span className="dropdown-menu" aria-labelledby="follow-dropdown">
-            <button className="dropdown-item select-item" onClick={this.toggleFollow}>
+            <button className="dropdown-item select-item" onClick={this.disableFollow.bind(this)}>
               {!this.state.followed ? <i className="fa fa-check select-item-indicator" aria-hidden="true" /> : null}
               {django.gettext('Unfollow')}
               <span className="select-item-desc">
                 {django.gettext('Never be notified.')}
               </span>
             </button>
-            <button className="dropdown-item select-item" onClick={this.toggleFollow}>
+            <button className="dropdown-item select-item" onClick={this.enableFollow.bind(this)}>
               {this.state.followed ? <i className="fa fa-check select-item-indicator" aria-hidden="true" /> : null}
               {django.gettext('Follow')}
               <span className="select-item-desc">

--- a/adhocracy4/follows/static/follows/FollowButton.jsx
+++ b/adhocracy4/follows/static/follows/FollowButton.jsx
@@ -41,7 +41,9 @@ class FollowButton extends React.Component {
       <span className="btngroup btngroup-gray">
         <span className="dropdown">
           <button className="btn btn-secondary dropdown-toggle" type="button" id="follow-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <i className="fa fa-star" aria-hidden="true" /> {django.gettext('Follow')} <i className="fa fa-caret-down" aria-hidden="true" />
+            <i className="fa fa-star" aria-hidden="true" />&nbsp;
+            {this.state.followed ? django.gettext('Unfollow') : django.gettext('Follow')}&nbsp;
+            <i className="fa fa-caret-down" aria-hidden="true" />
           </button>
           <span className="dropdown-menu" aria-labelledby="follow-dropdown">
             <button className="dropdown-item select-item" onClick={this.toggleFollow}>

--- a/adhocracy4/follows/static/follows/FollowButton.jsx
+++ b/adhocracy4/follows/static/follows/FollowButton.jsx
@@ -58,14 +58,14 @@ class FollowButton extends React.Component {
           <span className="dropdown-menu" aria-labelledby="follow-dropdown">
             <button className="dropdown-item select-item" onClick={this.disableFollow.bind(this)}>
               {!this.state.followed ? <i className="fa fa-check select-item-indicator" aria-hidden="true" /> : null}
-              {django.gettext('Unfollow')}
+              {django.gettext('Not following')}
               <span className="select-item-desc">
                 {django.gettext('Never be notified.')}
               </span>
             </button>
             <button className="dropdown-item select-item" onClick={this.enableFollow.bind(this)}>
               {this.state.followed ? <i className="fa fa-check select-item-indicator" aria-hidden="true" /> : null}
-              {django.gettext('Follow')}
+              {django.gettext('Following')}
               <span className="select-item-desc">
                 {django.gettext('Be notified if something happens in the project.')}
               </span>

--- a/adhocracy4/follows/static/follows/FollowButton.jsx
+++ b/adhocracy4/follows/static/follows/FollowButton.jsx
@@ -39,10 +39,27 @@ class FollowButton extends React.Component {
   render () {
     return (
       <span className="btngroup btngroup-gray">
-        <button className="btn btn-sm btn-dark btn-primary" type="button" onClick={this.toggleFollow.bind(this)}>
-          <i className={this.state.followed ? 'fa fa-star' : 'fa fa-star-o'} aria-hidden="true" />
-          &nbsp;{this.state.followed ? django.gettext('Unfollow') : django.gettext('Follow')}
-        </button>
+        <span className="dropdown">
+          <button className="btn btn-secondary dropdown-toggle" type="button" id="follow-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <i className="fa fa-star" aria-hidden="true" /> {django.gettext('Follow')} <i className="fa fa-caret-down" aria-hidden="true" />
+          </button>
+          <span className="dropdown-menu" aria-labelledby="follow-dropdown">
+            <button className="dropdown-item select-item" onClick={this.toggleFollow}>
+              {!this.state.followed ? <i className="fa fa-check select-item-indicator" aria-hidden="true" /> : null}
+              {django.gettext('Unfollow')}
+              <span className="select-item-desc">
+                {django.gettext('Never be notified.')}
+              </span>
+            </button>
+            <button className="dropdown-item select-item" onClick={this.toggleFollow}>
+              {this.state.followed ? <i className="fa fa-check select-item-indicator" aria-hidden="true" /> : null}
+              {django.gettext('Follow')}
+              <span className="select-item-desc">
+                {django.gettext('Be notified if something happens in the project.')}
+              </span>
+            </button>
+          </span>
+        </span>
         <span className="btn btn-sm btn-dark btn-primary">{this.state.follows}</span>
       </span>
     )


### PR DESCRIPTION
Clicking the button now opens a dropdown where the specific action is explained.

<img width="331" alt="follow dropdown" src="https://user-images.githubusercontent.com/16354712/29665398-30f8f018-88d4-11e7-8a96-73c1b1da56df.png">

This is breaking because it requires additional styling. See https://github.com/liqd/a4-meinberlin/pull/728. At least setting
```css
.select-item-desc {
    display: block;
}
```
is recommended, since I couldn't use any block elements due to then invalid html.