### PR TITLE
Add all static and template folders recursively to package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,4 @@
 include LICENSE
 include README
-recursive-include adhocracy4/images/static *
-recursive-include adhocracy4/images/templates *
-recursive-include adhocracy4/projects/templates *
-recursive-include adhocracy4/reports/templates *
-recursive-include adhocracy4/maps/templates *
-recursive-include adhocracy4/maps/static *
-recursive-include adhocracy4/filters/templates *
+recursive-include adhocracy4/*/static *
+recursive-include adhocracy4/*/templates *


### PR DESCRIPTION
Adding `static` and `templates` of all apps to the package, to avoid forgetting to add templates of new apps.

@slomo: Or was there a good reason to add them manually?