### PR TITLE
fix predicates to return False if argument is None

### DIFF
--- a/adhocracy4/comments/rules.py
+++ b/adhocracy4/comments/rules.py
@@ -6,10 +6,12 @@ from adhocracy4.phases import predicates as phase_predicates
 
 @rules.predicate
 def content_object_allows_comment(user, comment):
-    content_object = comment.content_object
-    return phase_predicates.has_feature_active(
-        content_object.module, content_object.__class__, 'comment'
-    )
+    if comment:
+        content_object = comment.content_object
+        return phase_predicates.has_feature_active(
+            content_object.module, content_object.__class__, 'comment'
+        )
+    return False
 
 
 rules.add_perm(

--- a/adhocracy4/modules/predicates.py
+++ b/adhocracy4/modules/predicates.py
@@ -12,79 +12,104 @@ from adhocracy4.projects.predicates import is_live
 
 @rules.predicate
 def is_context_initiator(user, item):
-    return is_initiator(user, item.project)
+    if item:
+        return is_initiator(user, item.project)
+    return False
 
 
 @rules.predicate
 def is_context_moderator(user, item):
-    return is_moderator(user, item.project)
+    if item:
+        return is_moderator(user, item.project)
+    return False
 
 
 @rules.predicate
 def is_context_member(user, item):
-    return is_member(user, item.project)
+    if item:
+        return is_member(user, item.project)
+    return False
 
 
 @rules.predicate
 def is_owner(user, item):
-    return item.creator == user
+    if item:
+        return item.creator == user
+    return False
 
 
 @rules.predicate
 def is_public_context(user, item):
-    return is_public(user, item.project)
+    if item:
+        return is_public(user, item.project)
+    return False
 
 
 @rules.predicate
 def is_live_context(user, item):
-    return is_live(user, item.project)
+    if item:
+        return is_live(user, item.project)
+    return False
 
 
 @rules.predicate
 def is_project_admin(user, item):
-    return (rules_predicates.is_superuser(user) |
-            is_context_moderator(user, item) |
-            is_context_initiator(user, item))
+    if item:
+        return (rules_predicates.is_superuser(user) |
+                is_context_moderator(user, item) |
+                is_context_initiator(user, item))
+    return False
 
 
 @rules.predicate
 def is_allowed_view_item(user, item):
-    return (is_project_admin(user, item) |
-            ((is_context_member(user, item) |
-              is_public_context(user, item)) &
-             is_live_context(user, item)))
+    if item:
+        return (is_project_admin(user, item) |
+                ((is_context_member(user, item) |
+                  is_public_context(user, item)) &
+                 is_live_context(user, item)))
+    return False
 
 
 def is_allowed_add_item(item_class):
     @rules.predicate
     def _add_item(user, module):
-        return (is_project_admin(user, module) |
-                (is_context_member(user, module) &
-                 is_live_context(user, module) &
-                 phase_predicates.phase_allows_add(item_class)(user, module)))
+        if module:
+            return (is_project_admin(user, module) |
+                    (is_context_member(user, module) &
+                     is_live_context(user, module) &
+                     phase_predicates.phase_allows_add(
+                        item_class)(user, module)))
+        return False
     return _add_item
 
 
 @rules.predicate
 def is_allowed_rate_item(user, item):
-    return (is_project_admin(user, item) |
-            (is_context_member(user, item) &
-             is_live_context(user, item) &
-             phase_predicates.phase_allows_rate(user, item)))
+    if item:
+        return (is_project_admin(user, item) |
+                (is_context_member(user, item) &
+                 is_live_context(user, item) &
+                 phase_predicates.phase_allows_rate(user, item)))
+    return False
 
 
 @rules.predicate
 def is_allowed_comment_item(user, item):
-    return (is_project_admin(user, item) |
-            (is_context_member(user, item) &
-             is_live_context(user, item) &
-             phase_predicates.phase_allows_comment(user, item)))
+    if item:
+        return (is_project_admin(user, item) |
+                (is_context_member(user, item) &
+                 is_live_context(user, item) &
+                 phase_predicates.phase_allows_comment(user, item)))
+    return False
 
 
 @rules.predicate
 def is_allowed_change_item(user, item):
-    return (is_project_admin(user, item) |
-            (is_context_member(user, item) &
-             is_live_context(user, item) &
-             is_owner(user, item) &
-             phase_predicates.phase_allows_change(user, item)))
+    if item:
+        return (is_project_admin(user, item) |
+                (is_context_member(user, item) &
+                 is_live_context(user, item) &
+                 is_owner(user, item) &
+                 phase_predicates.phase_allows_change(user, item)))
+    return False

--- a/adhocracy4/organisations/predicates.py
+++ b/adhocracy4/organisations/predicates.py
@@ -3,8 +3,10 @@ import rules
 
 @rules.predicate
 def is_initiator(user, subject):
-    if hasattr(subject, 'has_initiator'):
-        organisation = subject
-    else:
-        organisation = subject.organisation
-    return organisation.has_initiator(user)
+    if subject:
+        if hasattr(subject, 'has_initiator'):
+            organisation = subject
+        else:
+            organisation = subject.organisation
+        return organisation.has_initiator(user)
+    return False

--- a/adhocracy4/phases/predicates.py
+++ b/adhocracy4/phases/predicates.py
@@ -2,29 +2,39 @@ import rules
 
 
 def has_feature_active(module, model, feature):
-    if not module.active_phase:
-        return False
-    else:
-        return module.active_phase.has_feature(feature, model)
+    if module:
+        if not module.active_phase:
+            return False
+        else:
+            return module.active_phase.has_feature(feature, model)
+    return False
 
 
 @rules.predicate
 def phase_allows_change(user, item):
-    return has_feature_active(item.module, item.__class__, 'crud')
+    if item:
+        return has_feature_active(item.module, item.__class__, 'crud')
+    return False
 
 
 def phase_allows_add(item_class):
     @rules.predicate
     def _add_predicate(user, module):
-        return has_feature_active(module, item_class, 'crud')
+        if module:
+            return has_feature_active(module, item_class, 'crud')
+        return False
     return _add_predicate
 
 
 @rules.predicate
 def phase_allows_comment(user, item):
-    return has_feature_active(item.module, item.__class__, 'comment')
+    if item:
+        return has_feature_active(item.module, item.__class__, 'comment')
+    return False
 
 
 @rules.predicate
 def phase_allows_rate(user, item):
-    return has_feature_active(item.module, item.__class__, 'rate')
+    if item:
+        return has_feature_active(item.module, item.__class__, 'rate')
+    return False

--- a/adhocracy4/projects/predicates.py
+++ b/adhocracy4/projects/predicates.py
@@ -3,19 +3,27 @@ import rules
 
 @rules.predicate
 def is_member(user, project):
-    return project.has_member(user)
+    if project:
+        return project.has_member(user)
+    return False
 
 
 @rules.predicate
 def is_public(user, project):
-    return project.is_public
+    if project:
+        return project.is_public
+    return False
 
 
 @rules.predicate
 def is_live(user, project):
-    return not project.is_draft
+    if project:
+        return not project.is_draft
+    return False
 
 
 @rules.predicate
 def is_moderator(user, project):
-    return user in project.moderators.all()
+    if project:
+        return user in project.moderators.all()
+    return False

--- a/adhocracy4/ratings/rules.py
+++ b/adhocracy4/ratings/rules.py
@@ -6,10 +6,12 @@ from adhocracy4.phases import predicates as phase_predicates
 
 @rules.predicate
 def content_object_allows_rating(user, rating):
-    content_object = rating.content_object
-    return phase_predicates.has_feature_active(
-        content_object.module, content_object.__class__, 'rate'
-    )
+    if rating:
+        content_object = rating.content_object
+        return phase_predicates.has_feature_active(
+            content_object.module, content_object.__class__, 'rate'
+        )
+    return False
 
 
 rules.add_perm(


### PR DESCRIPTION
This PR enables django permissions work together with our rules system. Without these changes it is not possible to create a group with certain table-based permissions within the django admin, because the names of our rules have the same name pattern as djangos permissions. 

When the django admin is created django checks all permissions available if one of them returns true, but runs in an error when trying to call a predicate in one of our customs rules, as no project or item (whatever the permission_object is) is set. 

Another solution to fix this, would have been to change the name pattern of our rules, but we preferred this solution, as no more adaptions should be necessary now.