### PR TITLE
check if commenting is allowed for check if comments can be rated, commented, changed, or deleted

### DIFF
--- a/adhocracy4/comments/rules.py
+++ b/adhocracy4/comments/rules.py
@@ -1,15 +1,17 @@
 import rules
 
 from adhocracy4.modules import predicates as module_predicates
-from adhocracy4.phases import predicates as phase_predicates
 
 
 @rules.predicate
 def content_object_allows_comment(user, comment):
     content_object = comment.content_object
-    return phase_predicates.has_feature_active(
-        content_object.module, content_object.__class__, 'comment'
+    content_type = comment.content_type
+    perm_name = '{app_label}.comment_{model}'.format(
+        app_label=content_type.app_label,
+        model=content_type.model
     )
+    return user.has_perm(perm_name, content_object)
 
 
 rules.add_perm(

--- a/adhocracy4/ratings/rules.py
+++ b/adhocracy4/ratings/rules.py
@@ -1,15 +1,17 @@
 import rules
 
 from adhocracy4.modules import predicates as module_predicates
-from adhocracy4.phases import predicates as phase_predicates
 
 
 @rules.predicate
 def content_object_allows_rating(user, rating):
     content_object = rating.content_object
-    return phase_predicates.has_feature_active(
-        content_object.module, content_object.__class__, 'rate'
+    content_type = rating.content_type
+    perm_name = '{app_label}.rate_{model}'.format(
+        app_label=content_type.app_label,
+        model=content_type.model
     )
+    return user.has_perm(perm_name, content_object)
 
 
 rules.add_perm(


### PR DESCRIPTION
The predicate, which is tested to decide if comments can be rated, commented, changed, or deleted checked if the phase allowed commenting. Instead it should check and does check now if commenting is allowed for that content_type, like in the comment create rule.

From now on, you'll have to make sure, that you test for the phase in the rule in your project. But you will test it there anyway, otherwise commenting would be allowed, even if the phase doesn't.