### PR TITLE
fallback tiny image for image upload without picture

### DIFF
--- a/adhocracy4/images/templates/a4images/image_upload_widget.html
+++ b/adhocracy4/images/templates/a4images/image_upload_widget.html
@@ -26,7 +26,7 @@
         <div class="form-{{ id }}">
             {{ checkbox_input }}
             <img class="img-responsive" id="{{ file_id }}"
-                 src="{% if has_image_set %}{{ file_url }}{% endif %}"
+                 src="{% if has_image_set %}{{ file_url }}{% else %}data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs={% endif %}"
                  data-upload-preview="{{ id }}"
                  alt=""
             >


### PR DESCRIPTION
HTML was invalid before. It's easier than  removing the img tag and dynamically inserting one via JS because that would require a bigger rewrite of the js upload code.

The picture is invisible, it's a transparent gif.