### PR TITLE
remove empty action attribute

### DIFF
--- a/adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html
+++ b/adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html
@@ -5,7 +5,7 @@
         {{ label }}
     </label>
     <br>
-    <form class="search-filter" action="" method="get">
+    <form class="search-filter" method="get">
         {% for par_name, value in url_par.items %}
             {% if par_name != name %}
                 <input type="hidden" name="{{ par_name }}" value="{{ value }}">


### PR DESCRIPTION
Having the action attribute empty is invalid HTML, omitting it will send the data to the current page.