### PR TITLE
clearify connection between "follow" and "email"

### DIFF
--- a/adhocracy4/follows/static/follows/FollowButton.jsx
+++ b/adhocracy4/follows/static/follows/FollowButton.jsx
@@ -67,7 +67,7 @@ class FollowButton extends React.Component {
               {this.state.followed ? <i className="fa fa-check select-item-indicator" aria-hidden="true" /> : null}
               {django.gettext('Following')}
               <span className="select-item-desc">
-                {django.gettext('Be notified if something happens in the project.')}
+                {django.gettext('Receive email notifications about this project.')}
               </span>
             </button>
           </span>


### PR DESCRIPTION
see also https://github.com/liqd/a4-meinberlin/pull/787

we got the feedback that the connection between "email", "notification", and
"follow" is not completely clear.

@janaba what do you think of this change?