### PR TITLE
Project Dispatcher

### DIFF
--- a/adhocracy4/projects/views.py
+++ b/adhocracy4/projects/views.py
@@ -1,14 +1,20 @@
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+from django.shortcuts import get_object_or_404
 from django.views import generic
 from rules.contrib import views as rules_views
 
-from . import mixins, models
+from adhocracy4.modules.models import Module
+
+from .mixins import PhaseDispatchMixin
+from .models import Project
 
 
 class ProjectDetailView(rules_views.PermissionRequiredMixin,
-                        mixins.PhaseDispatchMixin,
+                        PhaseDispatchMixin,
                         generic.DetailView):
 
-    model = models.Project
+    model = Project
     permission_required = 'a4projects.view_project'
 
     @property
@@ -21,3 +27,111 @@ class ProjectDetailView(rules_views.PermissionRequiredMixin,
         Emulate ProjectMixin interface for template sharing.
         """
         return self.get_object()
+
+
+class ProjectContextDispatcher(generic.base.ContextMixin, generic.View):
+    """Add project and module attributes to the view.
+
+    This acts as a replacement of ProjectMixin and
+    is a counterpart to the PhaseDispatcher logic.
+
+    Note: Must always be defined as the _first_ parent class.
+    """
+
+    module = None
+    project = None
+
+    project_lookup_field = 'slug'
+    project_url_kwarg = 'project_slug'
+    module_lookup_field = 'slug'
+    module_url_kwarg = 'module_slug'
+
+    def get_module(self, *args, **kwargs):
+        """Get the module from the kwargs, url or current object.
+
+        Note: May be overwritten by views with different module relations.
+        """
+        if 'module' in kwargs and isinstance(kwargs['module'], Module):
+            return kwargs['module']
+
+        if self.module_url_kwarg and self.module_url_kwarg in kwargs:
+            lookup = {
+                self.module_lookup_field: kwargs[self.module_url_kwarg]
+            }
+            return get_object_or_404(Module, **lookup)
+
+        return self._get_object(Module, 'module')
+
+    def get_project(self, *args, **kwargs):
+        """Get the project from the module, kwargs, url or current object.
+
+        Note: May be overwritten by views with different projects relations.
+        """
+        if self.module:
+            return self.module.project
+
+        if 'project' in kwargs and isinstance(kwargs['project'], Project):
+            return kwargs['project']
+
+        if self.project_url_kwarg and self.project_url_kwarg in kwargs:
+            lookup = {
+                self.project_lookup_field: kwargs[self.project_url_kwarg]
+            }
+            return get_object_or_404(Project, **lookup)
+
+        return self._get_object(Project, 'project')
+
+    def validate_object_project(self):
+        """Validate that the current objects project matches the context."""
+        object_project = self._get_object(Project, 'project')
+        return not object_project or object_project == self.project
+
+    def validate_object_module(self):
+        """Validate that the current objects module matches the context."""
+        object_module = self._get_object(Module, 'module')
+        return not object_module or object_module == self.module
+
+    def _get_object(self, cls, attr):
+        if hasattr(self, 'get_object') \
+                and not isinstance(self, generic.CreateView):
+            try:
+                object = self.get_object()
+                if isinstance(object, cls):
+                    return object
+
+                if hasattr(object, attr):
+                    return getattr(object, attr)
+            except Http404:
+                return None
+            except AttributeError:
+                return None
+
+        return None
+
+    def dispatch(self, request, *args, **kwargs):
+        """Get this contexts project and module and validate them."""
+        module = self.get_module(*args, **kwargs)
+        self.module = module
+        self.request.module = module
+
+        project = self.get_project(*args, **kwargs)
+        self.project = project
+        self.request.project = project
+
+        if not project:
+            raise Http404()
+
+        if not self.validate_object_project() \
+                or not self.validate_object_module():
+            raise PermissionDenied()
+
+        return super(ProjectContextDispatcher, self) \
+            .dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        """Append project and module to the template context."""
+        if 'project' not in kwargs:
+            kwargs['project'] = self.project
+        if 'module' not in kwargs:
+            kwargs['module'] = self.module
+        return super(ProjectContextDispatcher, self).get_context_data(**kwargs)

--- a/adhocracy4/projects/views.py
+++ b/adhocracy4/projects/views.py
@@ -112,11 +112,9 @@ class ProjectContextDispatcher(generic.base.ContextMixin, generic.View):
         """Get this contexts project and module and validate them."""
         module = self.get_module(*args, **kwargs)
         self.module = module
-        self.request.module = module
 
         project = self.get_project(*args, **kwargs)
         self.project = project
-        self.request.project = project
 
         if not project:
             raise Http404()

--- a/tests/projects/test_project_views.py
+++ b/tests/projects/test_project_views.py
@@ -76,7 +76,6 @@ def test_project_context_kwargs(rf, project):
 
     assert response.content == b'project_context'
     assert view.project == project
-    assert request.project == project
 
 
 @pytest.mark.django_db
@@ -87,7 +86,6 @@ def test_project_context_url(rf, project):
 
     assert response.content == b'project_context'
     assert view.project == project
-    assert request.project == project
 
 
 @pytest.mark.django_db
@@ -102,7 +100,6 @@ def test_project_context_url_overwrite(rf, project):
 
     assert response.content == b'project_context'
     assert view.project == project
-    assert request.project == project
 
 
 @pytest.mark.django_db
@@ -116,7 +113,6 @@ def test_project_context_object(rf, project):
 
     assert response.content == b'project_context'
     assert view.project == project
-    assert request.project == project
 
 
 @pytest.mark.django_db
@@ -130,7 +126,6 @@ def test_project_context_project_object(rf, project):
 
     assert response.content == b'project_context'
     assert view.project == project
-    assert request.project == project
 
 
 @pytest.mark.django_db
@@ -145,7 +140,6 @@ def test_project_context_overwrite(rf, project):
 
     assert response.content == b'project_context'
     assert view.project == project
-    assert request.project == project
 
 
 @pytest.mark.django_db

--- a/tests/projects/test_project_views.py
+++ b/tests/projects/test_project_views.py
@@ -1,7 +1,13 @@
 import pytest
+from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
+from django.http import Http404
+from django.http import HttpResponse
 
+from adhocracy4.projects import views
 from adhocracy4.test.helpers import redirect_target
+
+from unittest import mock
 
 
 @pytest.mark.django_db
@@ -46,3 +52,227 @@ def test_detail_draft_project(client, project, user, staff_user):
     response = client.get(project_url)
     assert response.status_code == 200
     assert response.context_data['view'].project == project
+
+
+def dispatch_view(view_class, request, *args, **kwargs):
+    """Mimic as_view() and dispatch() but returns view instance in addition."""
+    view = view_class()
+    view.request = request
+    view.args = args
+    view.kwargs = kwargs
+    return view.dispatch(request, *args, **kwargs), view
+
+
+class FakeProjectContextView(views.ProjectContextDispatcher):
+    def get(self, request, *args, **kwargs):
+        return HttpResponse('project_context')
+
+
+@pytest.mark.django_db
+def test_project_context_kwargs(rf, project):
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextView, request,
+                                   project=project)
+
+    assert response.content == b'project_context'
+    assert view.project == project
+    assert request.project == project
+
+
+@pytest.mark.django_db
+def test_project_context_url(rf, project):
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextView, request,
+                                   project_slug=project.slug)
+
+    assert response.content == b'project_context'
+    assert view.project == project
+    assert request.project == project
+
+
+@pytest.mark.django_db
+def test_project_context_url_overwrite(rf, project):
+    class FakeProjectContextViewUrlOverwrite(FakeProjectContextView):
+        project_lookup_field = 'id'
+        project_url_kwarg = 'project_id'
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextViewUrlOverwrite, request,
+                                   project_id=project.id)
+
+    assert response.content == b'project_context'
+    assert view.project == project
+    assert request.project == project
+
+
+@pytest.mark.django_db
+def test_project_context_object(rf, project):
+    class FakeProjectContextGetObjectView(FakeProjectContextView):
+        def get_object(self):
+            return mock.Mock(project=project, module=None)
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextGetObjectView, request)
+
+    assert response.content == b'project_context'
+    assert view.project == project
+    assert request.project == project
+
+
+@pytest.mark.django_db
+def test_project_context_project_object(rf, project):
+    class FakeProjectContextGetObjectView(FakeProjectContextView):
+        def get_object(self):
+            return project
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextGetObjectView, request)
+
+    assert response.content == b'project_context'
+    assert view.project == project
+    assert request.project == project
+
+
+@pytest.mark.django_db
+def test_project_context_overwrite(rf, project):
+    class FakeProjectContextGetProjectView(FakeProjectContextView):
+        def get_project(self, *args, **kwargs):
+            return project
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextGetProjectView,
+                                   request)
+
+    assert response.content == b'project_context'
+    assert view.project == project
+    assert request.project == project
+
+
+@pytest.mark.django_db
+def test_project_context_missing(rf):
+    request = rf.get('/url')
+    with pytest.raises(Http404):
+        dispatch_view(FakeProjectContextView, request)
+
+
+@pytest.mark.django_db
+def test_project_context_invalid(rf, project_factory):
+    class FakeProjectContextViewInvalid(FakeProjectContextView):
+        def get_project(self, *args, **kwargs):
+            return project_factory()
+
+        def get_object(self):
+            return mock.Mock(project=project_factory())
+
+    request = rf.get('/url')
+    with pytest.raises(PermissionDenied):
+        dispatch_view(FakeProjectContextViewInvalid, request)
+
+
+@pytest.mark.django_db
+def test_project_template_context(rf, project):
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextView,
+                                   request, project=project)
+
+    context = view.get_context_data()
+    assert context['project'] == project
+
+
+@pytest.mark.django_db
+def test_module_context_kwargs(rf, module):
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextView,
+                                   request, module=module)
+
+    assert response.content == b'project_context'
+    assert view.module == module
+    assert view.project == module.project
+
+
+@pytest.mark.django_db
+def test_module_context_url(rf, module):
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextView,
+                                   request,
+                                   module_slug=module.slug)
+
+    assert response.content == b'project_context'
+    assert view.module == module
+
+
+@pytest.mark.django_db
+def test_module_context_url_overwrite(rf, module):
+    class FakeProjectContextViewUrlOverwrite(FakeProjectContextView):
+        module_lookup_field = 'id'
+        module_url_kwarg = 'module_id'
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextViewUrlOverwrite, request,
+                                   module_id=module.id)
+
+    assert response.content == b'project_context'
+    assert view.module == module
+
+
+@pytest.mark.django_db
+def test_module_context_object(rf, module):
+    class FakeProjectContextGetObjectView(FakeProjectContextView):
+        def get_object(self):
+            return mock.Mock(module=module, project=None)
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextGetObjectView, request)
+
+    assert response.content == b'project_context'
+    assert view.module == module
+
+
+@pytest.mark.django_db
+def test_module_context_module_object(rf, module):
+    class FakeProjectContextGetObjectView(FakeProjectContextView):
+        def get_object(self):
+            return module
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextGetObjectView, request)
+
+    assert response.content == b'project_context'
+    assert view.module == module
+
+
+@pytest.mark.django_db
+def test_module_context_overwrite(rf, module):
+    class FakeProjectContextGetProjectView(FakeProjectContextView):
+        def get_module(self, *args, **kwargs):
+            return module
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextGetProjectView, request)
+
+    assert response.content == b'project_context'
+    assert view.module == module
+
+
+@pytest.mark.django_db
+def test_module_context_invalid(rf, module_factory):
+    class FakeProjectContextViewInvalid(FakeProjectContextView):
+        def get_project(self, *args, **kwargs):
+            return module_factory()
+
+        def get_object(self):
+            return mock.Mock(module=module_factory())
+
+    request = rf.get('/url')
+    with pytest.raises(PermissionDenied):
+        dispatch_view(FakeProjectContextViewInvalid, request)
+
+
+@pytest.mark.django_db
+def test_module_template_context(rf, module):
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextView,
+                                   request, module=module)
+
+    context = view.get_context_data()
+    assert context['module'] == module


### PR DESCRIPTION
Implements the project/module view helper suggested in #134 

It sets the module and project in different view scenarios:

- kwargs
- url
- get_object

This is a copy of the working solution from a4-meinberlin and could be used in the core dashboard as well.