### PR TITLE
Use prop-types package (fixes react deprecation warnings)

### DIFF
--- a/adhocracy4/comments/static/comments/Comment.jsx
+++ b/adhocracy4/comments/static/comments/Comment.jsx
@@ -7,6 +7,7 @@ var CommentReplyBar = require('./CommentReplyBar')
 var CommentManageDropdown = require('./CommentManageDropdown')
 
 var React = require('react')
+var PropTypes = require('prop-types')
 var django = require('django')
 
 var safeHtml = function (text) {
@@ -174,11 +175,11 @@ class Comment extends React.Component {
 }
 
 Comment.contextTypes = {
-  comments_contenttype: React.PropTypes.number,
-  isAuthenticated: React.PropTypes.bool,
-  isModerator: React.PropTypes.bool,
-  user_name: React.PropTypes.string,
-  contentType: React.PropTypes.number
+  comments_contenttype: PropTypes.number,
+  isAuthenticated: PropTypes.bool,
+  isModerator: PropTypes.bool,
+  user_name: PropTypes.string,
+  contentType: PropTypes.number
 }
 
 module.exports = Comment

--- a/adhocracy4/comments/static/comments/CommentBox.jsx
+++ b/adhocracy4/comments/static/comments/CommentBox.jsx
@@ -4,6 +4,7 @@ var api = require('../../../static/api')
 
 var React = require('react')
 var update = require('immutability-helper')
+var PropTypes = require('prop-types')
 var django = require('django')
 
 class CommentBox extends React.Component {
@@ -95,10 +96,10 @@ class CommentBox extends React.Component {
 }
 
 CommentBox.childContextTypes = {
-  isAuthenticated: React.PropTypes.bool,
-  isModerator: React.PropTypes.bool,
-  comments_contenttype: React.PropTypes.number,
-  user_name: React.PropTypes.string
+  isAuthenticated: PropTypes.bool,
+  isModerator: PropTypes.bool,
+  comments_contenttype: PropTypes.number,
+  user_name: PropTypes.string
 }
 
 module.exports = CommentBox

--- a/adhocracy4/comments/static/comments/CommentEditForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentEditForm.jsx
@@ -1,4 +1,5 @@
 var React = require('react')
+var PropTypes = require('prop-types')
 var django = require('django')
 
 class CommentEditForm extends React.Component {
@@ -41,7 +42,7 @@ class CommentEditForm extends React.Component {
 }
 
 CommentEditForm.contextTypes = {
-  isAuthenticated: React.PropTypes.bool
+  isAuthenticated: PropTypes.bool
 }
 
 module.exports = CommentEditForm

--- a/adhocracy4/comments/static/comments/CommentForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentForm.jsx
@@ -1,6 +1,7 @@
 var config = require('../../../static/config')
 
 var React = require('react')
+var PropTypes = require('prop-types')
 var django = require('django')
 
 class CommentForm extends React.Component {
@@ -56,7 +57,7 @@ class CommentForm extends React.Component {
 }
 
 CommentForm.contextTypes = {
-  isAuthenticated: React.PropTypes.bool
+  isAuthenticated: PropTypes.bool
 }
 
 module.exports = CommentForm

--- a/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
+++ b/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
@@ -1,4 +1,5 @@
 var React = require('react')
+var PropTypes = require('prop-types')
 var django = require('django')
 
 const CommentManageDropdown = (props) => {
@@ -15,12 +16,10 @@ const CommentManageDropdown = (props) => {
               <button type="button" onClick={props.toggleEdit}>{django.gettext('Edit')}</button>
             </li>,
             <li className="divider" key="2" />,
-            <li key="3"><a href={`#comment_delete_${props.id}`} data-toggle="modal"
-              >{django.gettext('Delete')}</a></li>,
+            <li key="3"><a href={`#comment_delete_${props.id}`} data-toggle="modal">{django.gettext('Delete')}</a></li>,
             <li className="divider" key="4" />
           ]}
-          <li><a href={`#report_comment_${props.id}`} data-toggle="modal"
-            >{django.gettext('Report')}</a>
+          <li><a href={`#report_comment_${props.id}`} data-toggle="modal">{django.gettext('Report')}</a>
           </li>
         </ul>
       </li>
@@ -29,9 +28,9 @@ const CommentManageDropdown = (props) => {
 }
 
 CommentManageDropdown.propTypes = {
-  toggleEdit: React.PropTypes.func,
-  id: React.PropTypes.number,
-  renderModeratorOptions: React.PropTypes.bool
+  toggleEdit: PropTypes.func,
+  id: PropTypes.number,
+  renderModeratorOptions: PropTypes.bool
 }
 
 module.exports = CommentManageDropdown

--- a/adhocracy4/comments/static/comments/CommentReplyBar.jsx
+++ b/adhocracy4/comments/static/comments/CommentReplyBar.jsx
@@ -1,4 +1,5 @@
 var React = require('react')
+var PropTypes = require('prop-types')
 var django = require('django')
 
 function pluralizeString (number) {
@@ -43,9 +44,9 @@ const CommentReplyBar = (props) => {
 }
 
 CommentReplyBar.propTypes = {
-  childCommentsLength: React.PropTypes.number,
-  showComments: React.PropTypes.func,
-  allowForm: React.PropTypes.bool
+  childCommentsLength: PropTypes.number,
+  showComments: PropTypes.func,
+  allowForm: PropTypes.bool
 }
 
 module.exports = CommentReplyBar

--- a/adhocracy4/static/Modal.jsx
+++ b/adhocracy4/static/Modal.jsx
@@ -1,4 +1,5 @@
 let React = require('react')
+let PropTypes = require('prop-types')
 let django = require('django')
 
 export const Modal = (props) => {
@@ -39,8 +40,8 @@ export const Modal = (props) => {
 }
 
 Modal.propTypes = {
-  submitHandler: React.PropTypes.func,
-  closeHandler: React.PropTypes.func
+  submitHandler: PropTypes.func,
+  closeHandler: PropTypes.func
 }
 
 Modal.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "15.6.1",
     "immutability-helper": "^2.3.0",
     "react-dom": "15.6.1",
+    "prop-types": "15.6.0",
     "leaflet": "^1.0.3",
     "leaflet-draw": "^0.4.2"
   },


### PR DESCRIPTION
React emitted the appended warning that using `React.PropTypes` is
depreacted in favor of the separate package 'prop-types'. This PR adapts
to these changes.

> Accessing PropTypes via the main React package is deprecated, and will
> be removed in  React v16.0. Use the latest available v15.* prop-types
> package from npm instead. For info on usage, compatibility, migration
> and more, see https://fb.me/prop-types-docs