### PR TITLE
use caret version range for npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   ],
   "dependencies": {
     "classnames": "^2.2.5",
-    "jquery": "3.2.1",
-    "js-cookie": "~2.1.2",
-    "react": "15.6.1",
+    "jquery": "^3.2.1",
+    "js-cookie": "^2.1.2",
+    "react": "^15.6.1",
     "immutability-helper": "^2.3.0",
-    "react-dom": "15.6.1",
-    "prop-types": "15.6.0",
+    "react-dom": "^15.6.1",
+    "prop-types": "^15.6.0",
     "leaflet": "^1.0.3",
     "leaflet-draw": "^0.4.2"
   },


### PR DESCRIPTION
With python, we do not pin dependency versions in this repo, but on the concrete projects (meinberlin, opin, …). I propose to do the same with npm.  This prevent version conflicts and installing two versions of the same library.