### PR TITLE
add normal user and template tag to discover cta-buttons

### DIFF
--- a/adhocracy4/comments/static/comments/CommentBox.jsx
+++ b/adhocracy4/comments/static/comments/CommentBox.jsx
@@ -73,7 +73,8 @@ class CommentBox extends React.Component {
       isAuthenticated: this.props.isAuthenticated,
       isModerator: this.props.isModerator,
       comments_contenttype: this.props.comments_contenttype,
-      user_name: this.props.user_name
+      user_name: this.props.user_name,
+      would_comment_perm: this.props.would_comment_perm
     }
   }
   render () {
@@ -99,7 +100,8 @@ CommentBox.childContextTypes = {
   isAuthenticated: PropTypes.bool,
   isModerator: PropTypes.bool,
   comments_contenttype: PropTypes.number,
-  user_name: PropTypes.string
+  user_name: PropTypes.string,
+  would_comment_perm: PropTypes.bool
 }
 
 module.exports = CommentBox

--- a/adhocracy4/comments/static/comments/CommentBox.jsx
+++ b/adhocracy4/comments/static/comments/CommentBox.jsx
@@ -74,7 +74,7 @@ class CommentBox extends React.Component {
       isModerator: this.props.isModerator,
       comments_contenttype: this.props.comments_contenttype,
       user_name: this.props.user_name,
-      would_comment_perm: this.props.would_comment_perm
+      would_have_perm: this.props.would_have_perm
     }
   }
   render () {
@@ -101,7 +101,7 @@ CommentBox.childContextTypes = {
   isModerator: PropTypes.bool,
   comments_contenttype: PropTypes.number,
   user_name: PropTypes.string,
-  would_comment_perm: PropTypes.bool
+  would_have_perm: PropTypes.bool
 }
 
 module.exports = CommentBox

--- a/adhocracy4/comments/static/comments/CommentBox.jsx
+++ b/adhocracy4/comments/static/comments/CommentBox.jsx
@@ -73,8 +73,7 @@ class CommentBox extends React.Component {
       isAuthenticated: this.props.isAuthenticated,
       isModerator: this.props.isModerator,
       comments_contenttype: this.props.comments_contenttype,
-      user_name: this.props.user_name,
-      would_have_perm: this.props.would_have_perm
+      user_name: this.props.user_name
     }
   }
   render () {
@@ -100,8 +99,7 @@ CommentBox.childContextTypes = {
   isAuthenticated: PropTypes.bool,
   isModerator: PropTypes.bool,
   comments_contenttype: PropTypes.number,
-  user_name: PropTypes.string,
-  would_have_perm: PropTypes.bool
+  user_name: PropTypes.string
 }
 
 module.exports = CommentBox

--- a/adhocracy4/comments/static/comments/CommentForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentForm.jsx
@@ -40,7 +40,7 @@ class CommentForm extends React.Component {
           <input type="submit" value={django.gettext('post')} className="submit-button" />
         </form>
       )
-    } else if (!this.context.isAuthenticated) {
+    } else if (this.context.would_comment_perm) {
       return (
         <div className="comments_login">
           <a href={config.loginUrl}>{django.gettext('Please login to comment')}</a>
@@ -57,7 +57,8 @@ class CommentForm extends React.Component {
 }
 
 CommentForm.contextTypes = {
-  isAuthenticated: PropTypes.bool
+  isAuthenticated: PropTypes.bool,
+  would_comment_perm: PropTypes.bool
 }
 
 module.exports = CommentForm

--- a/adhocracy4/comments/static/comments/CommentForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentForm.jsx
@@ -40,7 +40,7 @@ class CommentForm extends React.Component {
           <input type="submit" value={django.gettext('post')} className="submit-button" />
         </form>
       )
-    } else if (this.context.would_have_perm) {
+    } else if (!this.props.isReadOnly) {
       return (
         <div className="comments_login">
           <a href={config.loginUrl}>{django.gettext('Please login to comment')}</a>
@@ -57,8 +57,7 @@ class CommentForm extends React.Component {
 }
 
 CommentForm.contextTypes = {
-  isAuthenticated: PropTypes.bool,
-  would_have_perm: PropTypes.bool
+  isAuthenticated: PropTypes.bool
 }
 
 module.exports = CommentForm

--- a/adhocracy4/comments/static/comments/CommentForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentForm.jsx
@@ -40,7 +40,7 @@ class CommentForm extends React.Component {
           <input type="submit" value={django.gettext('post')} className="submit-button" />
         </form>
       )
-    } else if (this.context.would_comment_perm) {
+    } else if (this.context.would_have_perm) {
       return (
         <div className="comments_login">
           <a href={config.loginUrl}>{django.gettext('Please login to comment')}</a>
@@ -58,7 +58,7 @@ class CommentForm extends React.Component {
 
 CommentForm.contextTypes = {
   isAuthenticated: PropTypes.bool,
-  would_comment_perm: PropTypes.bool
+  would_have_perm: PropTypes.bool
 }
 
 module.exports = CommentForm

--- a/adhocracy4/comments/templatetags/react_comments.py
+++ b/adhocracy4/comments/templatetags/react_comments.py
@@ -6,6 +6,7 @@ from django.utils.html import format_html
 
 from ..models import Comment
 from ..serializers import ThreadSerializer
+from adhocracy4.rules.discovery import NormalUser
 
 register = template.Library()
 
@@ -28,6 +29,8 @@ def react_comments(context, obj):
     permission = '{ct.app_label}.comment_{ct.model}'.format(ct=contenttype)
     has_comment_permission = user.has_perm(permission, obj)
 
+    would_comment_permission = NormalUser().would_perm(permission, obj)
+
     comments_contenttype = ContentType.objects.get_for_model(Comment)
     pk = obj.pk
 
@@ -44,6 +47,7 @@ def react_comments(context, obj):
         'isModerator': is_moderator,
         'user_name': user_name,
         'isReadOnly': not has_comment_permission,
+        'would_comment_perm': would_comment_permission,
     }
 
     return format_html(

--- a/adhocracy4/comments/templatetags/react_comments.py
+++ b/adhocracy4/comments/templatetags/react_comments.py
@@ -29,7 +29,9 @@ def react_comments(context, obj):
     permission = '{ct.app_label}.comment_{ct.model}'.format(ct=contenttype)
     has_comment_permission = user.has_perm(permission, obj)
 
-    would_comment_permission = NormalUser().would_perm(permission, obj)
+    would_have_comment_permission = NormalUser().would_have_perm(
+        permission, obj
+    )
 
     comments_contenttype = ContentType.objects.get_for_model(Comment)
     pk = obj.pk
@@ -47,7 +49,7 @@ def react_comments(context, obj):
         'isModerator': is_moderator,
         'user_name': user_name,
         'isReadOnly': not has_comment_permission,
-        'would_comment_perm': would_comment_permission,
+        'would_have_perm': would_have_comment_permission,
     }
 
     return format_html(

--- a/adhocracy4/comments/templatetags/react_comments.py
+++ b/adhocracy4/comments/templatetags/react_comments.py
@@ -48,8 +48,8 @@ def react_comments(context, obj):
         'isAuthenticated': is_authenticated,
         'isModerator': is_moderator,
         'user_name': user_name,
-        'isReadOnly': not has_comment_permission,
-        'would_have_perm': would_have_comment_permission,
+        'isReadOnly': (not has_comment_permission and
+                       not would_have_comment_permission),
     }
 
     return format_html(

--- a/adhocracy4/ratings/templatetags/react_ratings.py
+++ b/adhocracy4/ratings/templatetags/react_ratings.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils.html import format_html
 
 from adhocracy4.ratings import models as rating_models
+from adhocracy4.rules.discovery import NormalUser
 
 register = template.Library()
 
@@ -17,6 +18,10 @@ def react_ratings(context, obj):
     contenttype = ContentType.objects.get_for_model(obj)
     permission = '{ct.app_label}.rate_{ct.model}'.format(ct=contenttype)
     has_rate_permission = user.has_perm(permission, obj)
+
+    would_have_rate_permission = NormalUser().would_have_perm(
+        permission, obj
+    )
 
     if user.is_authenticated():
         authenticated_as = user.username
@@ -45,6 +50,7 @@ def react_ratings(context, obj):
         'userRatingId': user_rating_id,
         'isReadOnly': not has_rate_permission,
         'style': 'ideas',
+        'would_have_perm': would_have_rate_permission,
     }
 
     return format_html(

--- a/adhocracy4/ratings/templatetags/react_ratings.py
+++ b/adhocracy4/ratings/templatetags/react_ratings.py
@@ -48,9 +48,9 @@ def react_ratings(context, obj):
         'negativeRatings': obj.negative_rating_count,
         'userRating': user_rating_value,
         'userRatingId': user_rating_id,
-        'isReadOnly': not has_rate_permission,
+        'isReadOnly': (not has_rate_permission and
+                       not would_have_rate_permission),
         'style': 'ideas',
-        'would_have_perm': would_have_rate_permission,
     }
 
     return format_html(

--- a/adhocracy4/rules/apps.py
+++ b/adhocracy4/rules/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class RulesConfig(AppConfig):
+    name = 'adhocracy4.rules'
+    label = 'a4rules'

--- a/adhocracy4/rules/discovery.py
+++ b/adhocracy4/rules/discovery.py
@@ -1,19 +1,17 @@
 import rules
+from django.contrib.auth.models import AnonymousUser
 
 
-class NormalUser():
+class NormalUser(AnonymousUser):
     """
     Fake user with same state as freshly registerted user.
     This fake user object is used to check wether a login would help
     to enable an action. This user doesn't have any previliges granted
     except that it is authenticated.
     """
-    username = 'NormalUser'
-    email = 'noreply@liqd.net'
-    password = ''
-    is_staff = False
-    is_active = True
-    is_superuser = False
+
+    def __str__(self):
+        return 'NormalUser'
 
     def is_authenticated(self):
         return True

--- a/adhocracy4/rules/discovery.py
+++ b/adhocracy4/rules/discovery.py
@@ -1,0 +1,22 @@
+import rules
+
+
+class NormalUser():
+    """
+    Fake user with same state as freshly registerted user.
+    This fake user object is used to check wether a login would help
+    to enable an action. This user doesn't have any previliges granted
+    except that it is authenticated.
+    """
+    username = 'NormalUser'
+    email = 'noreply@liqd.net'
+    password = ''
+    is_staff = False
+    is_active = True
+    is_superuser = False
+
+    def is_authenticated(self):
+        return True
+
+    def would_perm(self, perm, obj):
+        return rules.has_perm(perm, self, obj)

--- a/adhocracy4/rules/discovery.py
+++ b/adhocracy4/rules/discovery.py
@@ -18,5 +18,5 @@ class NormalUser():
     def is_authenticated(self):
         return True
 
-    def would_perm(self, perm, obj):
+    def would_have_perm(self, perm, obj):
         return rules.has_perm(perm, self, obj)

--- a/adhocracy4/rules/templatetags/discovery_tags.py
+++ b/adhocracy4/rules/templatetags/discovery_tags.py
@@ -6,9 +6,9 @@ register = template.Library()
 
 
 @register.assignment_tag
-def would_perm(perm, obj=None):
+def would_have_perm(perm, obj=None):
     """
     Check if the NormalUser has the given permission.
     This checks only permissions defined with django-rules.
     """
-    return NormalUser().would_perm(perm, obj)
+    return NormalUser().would_have_perm(perm, obj)

--- a/adhocracy4/rules/templatetags/discovery_tags.py
+++ b/adhocracy4/rules/templatetags/discovery_tags.py
@@ -1,0 +1,14 @@
+from django import template
+
+from adhocracy4.rules.discovery import NormalUser
+
+register = template.Library()
+
+
+@register.assignment_tag
+def would_perm(perm, obj=None):
+    """
+    Check if the NormalUser has the given permission.
+    This checks only permissions defined with django-rules.
+    """
+    return NormalUser().would_perm(perm, obj)

--- a/adhocracy4/rules/templatetags/discovery_tags.py
+++ b/adhocracy4/rules/templatetags/discovery_tags.py
@@ -12,3 +12,17 @@ def would_have_perm(perm, obj=None):
     This checks only permissions defined with django-rules.
     """
     return NormalUser().would_have_perm(perm, obj)
+
+
+@register.assignment_tag
+def has_or_would_have_perm(perm, user, obj=None):
+    """
+    Check if the NormalUser has the given permission.
+    This checks only permissions defined with django-rules.
+    """
+    if not hasattr(user, 'has_perm'):  # pragma: no cover
+        return False  # swapped user model that doesn't support permissions
+    elif user.is_authenticated():
+        return user.has_perm(perm, obj)
+    else:
+        return NormalUser().would_have_perm(perm, obj)

--- a/tests/apps/questions/rules.py
+++ b/tests/apps/questions/rules.py
@@ -7,3 +7,8 @@ rules.add_perm('a4test_questions.comment_question', is_allowed_comment_item)
 
 
 rules.add_perm('a4test_questions.rate_question', is_allowed_rate_item)
+
+rules.add_perm(
+    'a4test_questions.always_allow',
+    rules.predicates.is_authenticated
+)

--- a/tests/comments/test_templatetags.py
+++ b/tests/comments/test_templatetags.py
@@ -56,6 +56,7 @@ def test_react_rating_anonymous(rf, question, comment):
             'isModerator': False,
             'isReadOnly': True,
             'user_name': '',
+            'would_comment_perm': False,
         }
 
 
@@ -78,4 +79,5 @@ def test_react_rating_user(rf, user, phase, question, comment):
             'isModerator': False,
             'isReadOnly': False,
             'user_name': user.username,
+            'would_comment_perm': True,
         }

--- a/tests/comments/test_templatetags.py
+++ b/tests/comments/test_templatetags.py
@@ -56,7 +56,7 @@ def test_react_rating_anonymous(rf, question, comment):
             'isModerator': False,
             'isReadOnly': True,
             'user_name': '',
-            'would_comment_perm': False,
+            'would_have_perm': False,
         }
 
 
@@ -79,5 +79,5 @@ def test_react_rating_user(rf, user, phase, question, comment):
             'isModerator': False,
             'isReadOnly': False,
             'user_name': user.username,
-            'would_comment_perm': True,
+            'would_have_perm': True,
         }

--- a/tests/comments/test_templatetags.py
+++ b/tests/comments/test_templatetags.py
@@ -56,7 +56,6 @@ def test_react_rating_anonymous(rf, question, comment):
             'isModerator': False,
             'isReadOnly': True,
             'user_name': '',
-            'would_have_perm': False,
         }
 
 
@@ -79,5 +78,4 @@ def test_react_rating_user(rf, user, phase, question, comment):
             'isModerator': False,
             'isReadOnly': False,
             'user_name': user.username,
-            'would_have_perm': True,
         }

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = (
     'adhocracy4.follows.apps.FollowsConfig',
     'adhocracy4.filters.apps.FiltersConfig',
     'adhocracy4.forms.apps.FormsConfig',
+    'adhocracy4.rules.apps.RulesConfig',
 
     # adhocrayc4 generic apps
     'adhocracy4.ratings.apps.RatingsConfig',

--- a/tests/ratings/test_rating_templatetags.py
+++ b/tests/ratings/test_rating_templatetags.py
@@ -50,7 +50,8 @@ def test_react_rating_anonymous(rf, question):
         'positiveRatings': 0,
         'style': 'ideas',
         'userRating': None,
-        'userRatingId': -1
+        'userRatingId': -1,
+        'would_have_perm': False,
     }
 
 
@@ -66,4 +67,5 @@ def test_react_rating_user(rf, user, question, rating):
         'style': 'ideas',
         'userRating': rating.value,
         'userRatingId': rating.id,
+        'would_have_perm': False,
     }

--- a/tests/ratings/test_rating_templatetags.py
+++ b/tests/ratings/test_rating_templatetags.py
@@ -51,7 +51,6 @@ def test_react_rating_anonymous(rf, question):
         'style': 'ideas',
         'userRating': None,
         'userRatingId': -1,
-        'would_have_perm': False,
     }
 
 
@@ -67,5 +66,4 @@ def test_react_rating_user(rf, user, question, rating):
         'style': 'ideas',
         'userRating': rating.value,
         'userRatingId': rating.id,
-        'would_have_perm': False,
     }

--- a/tests/rules/test_rule_templatetags.py
+++ b/tests/rules/test_rule_templatetags.py
@@ -1,0 +1,45 @@
+import pytest
+
+from django.contrib.auth.models import AnonymousUser
+
+from adhocracy4.test.helpers import render_template
+
+
+@pytest.mark.django_db
+def test_would_have_perm(rf, question):
+    request = rf.get('/')
+    template = ('{% load discovery_tags %}'
+                '{% would_have_perm "a4test_questions.always_allow" '
+                'as would_add %}'
+                '{% if would_add %}'
+                'CALL TO ACTION!'
+                '{% endif %}')
+    context = {'request': request}
+
+    assert 'CALL TO ACTION!' == render_template(template, context)
+
+
+@pytest.mark.django_db
+def test_has_or_would_have_perm(rf, question, user):
+    request = rf.get('/')
+    request.user = user
+    template = ('{% load discovery_tags %}'
+                '{% has_or_would_have_perm "a4test_questions.always_allow" '
+                'request.user as would_add %}'
+                '{% if would_add %}'
+                'CALL TO ACTION!'
+                '{% endif %}')
+    context = {'request': request}
+
+    assert 'CALL TO ACTION!' == render_template(template, context)
+
+    request.user = AnonymousUser()
+    template = ('{% load discovery_tags %}'
+                '{% has_or_would_have_perm "a4test_questions.always_allow" '
+                'request.user as would_add %}'
+                '{% if would_add %}'
+                'CALL TO ACTION!'
+                '{% endif %}')
+    context = {'request': request}
+
+    assert 'CALL TO ACTION!' == render_template(template, context)


### PR DESCRIPTION
Adds a "normal user", who has no special permissions, but checks if a logged-in user would be allowed to do whatever the button promises.
The template tag can be used analogous to has_perm from the rules tags. Like here: https://github.com/liqd/a4-opin/pull/962/files
For the comments, the link "Please login to comments" is only displayed, when commenting is possible.