### PR TITLE
Make category field translateable

### DIFF
--- a/adhocracy4/categories/fields.py
+++ b/adhocracy4/categories/fields.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 from .models import Category
 
@@ -7,6 +8,7 @@ class CategoryField(models.ForeignKey):
 
     def __init__(self, *args, **kwargs):
         defaults = {
+            'verbose_name': _('Category'),
             'to': Category,
             'on_delete': models.SET_NULL,
             'null': True,

--- a/adhocracy4/categories/forms.py
+++ b/adhocracy4/categories/forms.py
@@ -1,5 +1,3 @@
-from django import forms
-
 from adhocracy4.categories import models as category_models
 
 
@@ -9,13 +7,16 @@ class CategorizableFieldMixin:
     def __init__(self, *args, **kwargs):
         module = kwargs.pop('module')
         super().__init__(*args, **kwargs)
-        queryset = category_models.Category.objects.filter(module=module)
-        self.fields[self.category_field_name] = forms.ModelChoiceField(
-            queryset=queryset,
-            empty_label=None,
-            required=False,
-        )
+
+        field = self.fields[self.category_field_name]
+        field.queryset = category_models.Category.objects.filter(module=module)
+
+        required = field.queryset.exists()
+        field.empty_label = None
+        field.required = required
+        field.widget.is_required = required
 
     def show_categories(self):
-        module_has_categories = len(self.fields['category'].queryset) > 0
+        field = self.fields[self.category_field_name]
+        module_has_categories = field.queryset.exists()
         return module_has_categories


### PR DESCRIPTION
The category fields had not been translated as the field had been
reinitialized instead of modified. With this PR the auto generated field
(with its localized verbose_name) will be kept and adapted to the
filtered queryset.

Furthermore the required parameter is set to true if there are any
categories for the module.