### PR TITLE
trigger change events on maps

### DIFF
--- a/adhocracy4/maps/static/a4maps/map_choose_point.js
+++ b/adhocracy4/maps/static/a4maps/map_choose_point.js
@@ -26,6 +26,7 @@ function createMarker ($, L, newlatln, oldlatln, basePolygon, map, name) {
         oldlatln = marker.getLatLng()
         var shape = marker.toGeoJSON()
         $('#id_' + name).val(JSON.stringify(shape))
+        $('#id_' + name).trigger('change')
       }
     })
     if (!markerInsidePolygon) {
@@ -128,6 +129,7 @@ var init = function () {
         marker = createMarker($, L, event.latlng, oldlatlng, basePolygon, map, name)
         var shape = marker.toGeoJSON()
         $('#id_' + name).val(JSON.stringify(shape))
+        $('#id_' + name).trigger('change')
       }
     })
 

--- a/adhocracy4/maps/static/a4maps/map_choose_polygon.js
+++ b/adhocracy4/maps/static/a4maps/map_choose_polygon.js
@@ -80,16 +80,19 @@ var init = function () {
       drawnItems.addLayer(layer)
       var shape = drawnItems.toGeoJSON()
       $('#id_' + name).val(JSON.stringify(shape))
+      $('#id_' + name).trigger('change')
     })
 
     map.on(L.Draw.Event.EDITED, function (event) {
       var shape = drawnItems.toGeoJSON()
       $('#id_' + name).val(JSON.stringify(shape))
+      $('#id_' + name).trigger('change')
     })
 
     map.on(L.Draw.Event.DELETED, function (event) {
       var shape = drawnItems.toGeoJSON()
       $('#id_' + name).val(JSON.stringify(shape))
+      $('#id_' + name).trigger('change')
     })
 
     $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {


### PR DESCRIPTION
In meinberlin we have a script that warns users before leaving a changed form. This fixes that script for maps.