### PR TITLE
Project Mixin extension

### DIFF
--- a/adhocracy4/projects/mixins.py
+++ b/adhocracy4/projects/mixins.py
@@ -1,6 +1,11 @@
+from django.http import Http404
 from django.http.response import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
 from django.views import generic
+
+from adhocracy4.modules.models import Module
+from adhocracy4.projects.models import Project
 
 
 class PhaseDispatchMixin(generic.DetailView):
@@ -49,8 +54,79 @@ class ModuleDispatchMixin(PhaseDispatchMixin):
 
 
 class ProjectMixin(generic.base.ContextMixin):
-    def dispatch(self, *args, **kwargs):
-        self.project = kwargs['project']
-        self.module = kwargs['module']
+    """Add project and module attributes to the view and the template context.
 
-        return super(ProjectMixin, self).dispatch(*args, **kwargs)
+    This is a counterpart to the Phase- / ModuleDispatcher logic.
+
+    To consider the object context from get_object() set the
+    get_context_from_object attribute. Enable this only if get_object() does
+    not access the project and module properties.
+    """
+
+    project_lookup_field = 'slug'
+    project_url_kwarg = 'project_slug'
+    module_lookup_field = 'slug'
+    module_url_kwarg = 'module_slug'
+    get_context_from_object = False
+
+    @property
+    def module(self):
+        """Get the module from the current object, kwargs or url."""
+        if self.get_context_from_object:
+            return self._get_object(Module, 'module')
+
+        if 'module' in self.kwargs \
+                and isinstance(self.kwargs['module'], Module):
+            return self.kwargs['module']
+
+        if self.module_url_kwarg and self.module_url_kwarg in self.kwargs:
+            lookup = {
+                self.module_lookup_field: self.kwargs[self.module_url_kwarg]
+            }
+            return get_object_or_404(Module, **lookup)
+
+    @property
+    def project(self):
+        """Get the project from the module, kwargs, url or current object."""
+        if self.module:
+            return self.module.project
+
+        if self.get_context_from_object:
+            return self._get_object(Project, 'project')
+
+        if 'project' in self.kwargs \
+                and isinstance(self.kwargs['project'], Project):
+            return self.kwargs['project']
+
+        if self.project_url_kwarg and self.project_url_kwarg in self.kwargs:
+            lookup = {
+                self.project_lookup_field: self.kwargs[self.project_url_kwarg]
+            }
+            return get_object_or_404(Project, **lookup)
+
+    def _get_object(self, cls, attr):
+        # CreateView supplies a defect get_object method and has to be excluded
+        if hasattr(self, 'get_object') \
+                and not isinstance(self, generic.CreateView):
+            try:
+                object = self.get_object()
+                if isinstance(object, cls):
+                    return object
+
+                if hasattr(object, attr):
+                    return getattr(object, attr)
+            except Http404:
+                return None
+            except AttributeError:
+                return None
+
+        return None
+
+    def get_context_data(self, **kwargs):
+        """Append project and module to the template context."""
+        if 'project' not in kwargs:
+            kwargs['project'] = self.project
+        if 'module' not in kwargs:
+            kwargs['module'] = self.module
+        return super().get_context_data(**kwargs)
+

--- a/adhocracy4/projects/mixins.py
+++ b/adhocracy4/projects/mixins.py
@@ -52,6 +52,5 @@ class ProjectMixin(generic.base.ContextMixin):
     def dispatch(self, *args, **kwargs):
         self.project = kwargs['project']
         self.module = kwargs['module']
-        self.phase = self.module.last_active_phase if self.module else None
 
         return super(ProjectMixin, self).dispatch(*args, **kwargs)

--- a/adhocracy4/projects/views.py
+++ b/adhocracy4/projects/views.py
@@ -14,10 +14,3 @@ class ProjectDetailView(rules_views.PermissionRequiredMixin,
     @property
     def raise_exception(self):
         return self.request.user.is_authenticated()
-
-    @property
-    def project(self):
-        """
-        Emulate ProjectMixin interface for template sharing.
-        """
-        return self.get_object()

--- a/adhocracy4/test/helpers.py
+++ b/adhocracy4/test/helpers.py
@@ -67,3 +67,12 @@ def patch_background_task_decorator(*decorated_modules):
         importlib.reload(module)
 
     return patcher, mocked_decorator
+
+
+def dispatch_view(view_class, request, *args, **kwargs):
+    """Mimic as_view() and dispatch() but returns view instance in addition."""
+    view = view_class()
+    view.request = request
+    view.args = args
+    view.kwargs = kwargs
+    return view.dispatch(request, *args, **kwargs), view

--- a/tests/projects/test_mixins.py
+++ b/tests/projects/test_mixins.py
@@ -60,7 +60,6 @@ def test_project_mixin(rf, question_list_view, phase):
     view_data = response.context_data['view']
     assert view_data.project == project
     assert view_data.module == module
-    assert view_data.phase == phase
 
 
 @pytest.mark.django_db
@@ -82,4 +81,3 @@ def test_project_inject_phase_after_finish(rf, phase_factory,
     view_data = response.context_data['view']
     assert view_data.project == project
     assert view_data.module == module
-    assert view_data.phase == phase

--- a/tests/projects/test_mixins.py
+++ b/tests/projects/test_mixins.py
@@ -1,11 +1,20 @@
+from unittest import mock
+
 import pytest
 from dateutil.parser import parse
 from django.http import HttpResponse
 from django.views.generic import ListView, View
 from freezegun import freeze_time
-from tests.apps.questions import models as question_models
 
 from adhocracy4.projects import mixins, models
+from adhocracy4.test.helpers import dispatch_view
+
+from tests.apps.questions import models as question_models
+
+
+class FakeProjectContextView(mixins.ProjectMixin, View):
+    def get(self, request, *args, **kwargs):
+        return HttpResponse('project_context')
 
 
 @pytest.fixture
@@ -48,21 +57,6 @@ def test_phase_dispatch_mixin_default(rf, project_detail_view, project):
 
 
 @pytest.mark.django_db
-def test_project_mixin(rf, question_list_view, phase):
-    module = phase.module
-    project = module.project
-    request = rf.get('/project_name/ideas')
-
-    with freeze_time(phase.start_date):
-        response = question_list_view(request, project=project, module=module)
-
-    response = question_list_view(request, project=project, module=module)
-    view_data = response.context_data['view']
-    assert view_data.project == project
-    assert view_data.module == module
-
-
-@pytest.mark.django_db
 def test_project_inject_phase_after_finish(rf, phase_factory,
                                            question_list_view):
     phase = phase_factory(
@@ -81,3 +75,148 @@ def test_project_inject_phase_after_finish(rf, phase_factory,
     view_data = response.context_data['view']
     assert view_data.project == project
     assert view_data.module == module
+
+
+@pytest.mark.django_db
+def test_project_mixin_kwargs(rf, project):
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextView, request,
+                                   project=project)
+    assert view.project == project
+
+
+@pytest.mark.django_db
+def test_project_mixin_url(rf, project):
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextView, request,
+                                   project_slug=project.slug)
+    assert view.project == project
+
+
+@pytest.mark.django_db
+def test_project_mixin_url_overwrite(rf, project):
+    class FakeProjectContextViewUrlOverwrite(FakeProjectContextView):
+        project_lookup_field = 'id'
+        project_url_kwarg = 'project_id'
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextViewUrlOverwrite, request,
+                                   project_id=project.id)
+    assert view.project == project
+
+
+@pytest.mark.django_db
+def test_project_mixin_object(rf, project):
+    class FakeProjectContextGetObjectView(FakeProjectContextView):
+        get_context_from_object = True
+
+        def get_object(self):
+            return mock.Mock(project=project, module=None)
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextGetObjectView, request)
+    assert view.project == project
+
+
+@pytest.mark.django_db
+def test_project_mixin_project_object(rf, project):
+    class FakeProjectContextGetObjectView(FakeProjectContextView):
+        get_context_from_object = True
+
+        def get_object(self):
+            return project
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextGetObjectView, request)
+    assert view.project == project
+
+
+@pytest.mark.django_db
+def test_project_mixin_overwrite(rf, project):
+    class FakeProjectContextGetProjectView(FakeProjectContextView):
+        @property
+        def project(self):
+            return project
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextGetProjectView,
+                                   request)
+    assert view.project == project
+
+
+@pytest.mark.django_db
+def test_project_mixin_module_kwargs(rf, module):
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextView,
+                                   request, module=module)
+    assert view.module == module
+    assert view.project == module.project
+
+
+@pytest.mark.django_db
+def test_project_mixin_module_url(rf, module):
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextView,
+                                   request,
+                                   module_slug=module.slug)
+    assert view.module == module
+
+
+@pytest.mark.django_db
+def test_project_mixin_module_url_overwrite(rf, module):
+    class FakeProjectContextViewUrlOverwrite(FakeProjectContextView):
+        module_lookup_field = 'id'
+        module_url_kwarg = 'module_id'
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextViewUrlOverwrite, request,
+                                   module_id=module.id)
+    assert view.module == module
+
+
+@pytest.mark.django_db
+def test_project_mixin_module_object(rf, module):
+    class FakeProjectContextGetObjectView(FakeProjectContextView):
+        get_context_from_object = True
+
+        def get_object(self):
+            return mock.Mock(module=module, project=None)
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextGetObjectView, request)
+    assert view.module == module
+
+
+@pytest.mark.django_db
+def test_project_mixin_module_object(rf, module):
+    class FakeProjectContextGetObjectView(FakeProjectContextView):
+        get_context_from_object = True
+
+        def get_object(self):
+            return module
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextGetObjectView, request)
+    assert view.module == module
+
+
+@pytest.mark.django_db
+def test_project_mixin_module_overwrite(rf, module):
+    class FakeProjectContextGetProjectView(FakeProjectContextView):
+        @property
+        def module(self):
+            return module
+
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextGetProjectView, request)
+    assert view.module == module
+
+
+@pytest.mark.django_db
+def test_project_mixin_template_context(rf, module):
+    request = rf.get('/url')
+    response, view = dispatch_view(FakeProjectContextView,
+                                   request, module=module)
+    context = view.get_context_data()
+    assert context['module'] == module
+    assert context['project'] == module.project


### PR DESCRIPTION
Implements the project/module view helper suggested in #134
Replaces  #185 and #115

It sets two properties `project` and `module` on each inheriting view. 
The properties may be derived
1. directly from a `project` or `module` kwarg as set by the Phase- and ModuleDispatcherMixin
2. from a configurable url parameter which defaults to `project_slug` and `module_slug`
3. from the object returned by `get_object` if the view property `get_context_from_object = True`

This PR is currently breaking due to commit 286d7bc4316a5613c9580 which removed the `phase` property from the mixin. It is not clear if the `phase` property is required by opin or if it is replaced by the `ProjectPhaseMixin`.

This is a copy of the working solution from a4-meinberlin and could be used in the core dashboard as well.