### PR TITLE
Adapt meinBerlin poll/vote api.js to QuestionRouter

### DIFF
--- a/adhocracy4/static/api.js
+++ b/adhocracy4/static/api.js
@@ -17,7 +17,7 @@ var api = (function () {
     report: baseURL + 'reports/',
     document: baseURL + 'modules/$moduleId/documents/',
     poll: baseURL + 'polls/',
-    pollvote: baseURL + 'pollvotes/',
+    pollvote: baseURL + 'polls/question/$questionId/vote/',
     follow: baseURL + 'follows/',
     comment: baseURL + 'contenttypes/$contentTypeId/objects/$objectPk/comments/',
     rating: baseURL + 'contenttypes/$contentTypeId/objects/$objectPk/ratings/'
@@ -140,9 +140,9 @@ var api = (function () {
           type: 'PUT'
         }, data)
       },
-      vote: function (data, questionId) {
-        return _sendRequest('pollvote', questionId, {
-          type: 'PUT'
+      vote: function (data) {
+        return _sendRequest('pollvote', {
+          type: 'POST'
         }, data)
       }
     }


### PR DESCRIPTION
As we have to enable Multiple Choices for the meinBerlin poll feature we decided to rewrite the voting api by introducing a proper QuestionRouter. 
This PR adapts the core api.js to the new meinBerlin API Interface

Before a weird hacky solution was used, where a put was sent, that contained the Question id as `pk` kwarg, altough in the end a Vote object was either updated or created.

Note: this PR is breaking for meinBerlin until we merge the accompanying PR