### PR TITLE
Strip newlines from email subjects and make SyncEmail a Mixin again

### DIFF
--- a/adhocracy4/emails/base.py
+++ b/adhocracy4/emails/base.py
@@ -1,3 +1,5 @@
+import re
+
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites import models as site_models
@@ -102,8 +104,10 @@ class EmailBase:
             else:
                 to_address = receiver
 
+            subject_clean = re.sub(r'[\r\n]', '', subject).strip()
+
             mail = EmailMultiAlternatives(
-                subject=subject.strip(),
+                subject=subject_clean,
                 body=text,
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 to=[to_address],

--- a/adhocracy4/emails/mixins.py
+++ b/adhocracy4/emails/mixins.py
@@ -1,7 +1,6 @@
 from email.mime.image import MIMEImage
 
 from django.contrib.staticfiles import finders
-from .base import EmailBase
 
 
 class PlatformEmailMixin:
@@ -29,7 +28,7 @@ class PlatformEmailMixin:
         return attachments
 
 
-class SyncEmailMixin(EmailBase):
+class SyncEmailMixin:
     """Send Emails synchronously."""
 
     @classmethod


### PR DESCRIPTION
This fixes #174 by replacing newlines from the subject.

Furthermore it makes the SyncEmailMixin a real Mixin again by removing it's inheritance from EmailBase. This may be breaking if
* SyncEmailMixin was used as the sole dependency of a concrete Email implementation
* SyncEmailMixin was defined after the Email or EmailBase dependency

In those cases the application code has to be adapted and the SyncEmailMixin used like:
```
from adhocracy4.emails import Email
from adhocracy4.emails.base import EmailBase
from adhocracy4.emails.mixins import SyncEmailMixin

class SomeEmail(SyncEmailMixin, EmailBase):
    pass

class SomePlatformMixinEmail(SyncEmailMixin, Email):
    pass
```
