### PR TITLE
Use kwargs with reverse

### DIFF
--- a/adhocracy4/modules/models.py
+++ b/adhocracy4/modules/models.py
@@ -36,7 +36,7 @@ class Module(models.Model):
         return "{} ({})".format(self.project, self.weight)
 
     def get_absolute_url(self):
-        return reverse('module-detail', args=[str(self.slug)])
+        return reverse('module-detail', kwargs=dict(slug=self.slug))
 
     @property
     def settings_instance(self):

--- a/adhocracy4/modules/models.py
+++ b/adhocracy4/modules/models.py
@@ -36,7 +36,7 @@ class Module(models.Model):
         return "{} ({})".format(self.project, self.weight)
 
     def get_absolute_url(self):
-        return reverse('module-detail', kwargs=dict(slug=self.slug))
+        return reverse('module-detail', kwargs=dict(module_slug=self.slug))
 
     @property
     def settings_instance(self):

--- a/adhocracy4/projects/models.py
+++ b/adhocracy4/projects/models.py
@@ -120,7 +120,7 @@ class Project(base.TimeStampedModel):
         super(Project, self).save(*args, **kwargs)
 
     def get_absolute_url(self):
-        return reverse('project-detail', args=[str(self.slug)])
+        return reverse('project-detail', kwargs=dict(slug=self.slug))
 
     def has_member(self, user):
         """


### PR DESCRIPTION
In a4-product we patch reverse to have support for the partner middleware.  However it works only with kwargs.

Fixed the reverse usage here, to be able to use get_absolute_url of project and module in a4-product.