### PR TITLE
Add error handling for comments

### DIFF
--- a/adhocracy4/comments/static/comments/Comment.jsx
+++ b/adhocracy4/comments/static/comments/Comment.jsx
@@ -75,6 +75,8 @@ class Comment extends React.Component {
           subjectType={this.props.content_type}
           subjectId={this.props.object_pk}
           comment={this.props.children}
+          error={this.props.editError}
+          handleErrorClick={() => this.props.handleEditErrorClick(this.props.index, this.props.parentIndex)}
           rows="5"
           handleCancel={this.toggleEdit.bind(this)}
           onCommentSubmit={newComment => {
@@ -162,6 +164,7 @@ class Comment extends React.Component {
               handleCommentDelete={this.props.handleCommentDelete}
               handleCommentModify={this.props.handleCommentModify}
               isReadOnly={this.props.isReadOnly}
+              handleEditErrorClick={this.props.handleEditErrorClick}
             />
             <CommentForm
               subjectType={this.context.comments_contenttype}
@@ -169,6 +172,8 @@ class Comment extends React.Component {
               onCommentSubmit={this.props.handleCommentSubmit}
               parentIndex={this.props.index}
               placeholder={django.gettext('Your reply here')}
+              error={this.props.replyError}
+              handleErrorClick={() => this.props.handleReplyErrorClick(this.props.index, this.props.parentIndex)}
               rows="3"
             />
           </div> : null

--- a/adhocracy4/comments/static/comments/Comment.jsx
+++ b/adhocracy4/comments/static/comments/Comment.jsx
@@ -79,7 +79,11 @@ class Comment extends React.Component {
           handleCancel={this.toggleEdit.bind(this)}
           onCommentSubmit={newComment => {
             this.props.handleCommentModify(newComment, this.props.index, this.props.parentIndex)
-            this.state.edit = false
+              .then(() => {
+                this.setState({
+                  edit: false
+                })
+              })
           }}
         />
       )

--- a/adhocracy4/comments/static/comments/CommentBox.jsx
+++ b/adhocracy4/comments/static/comments/CommentBox.jsx
@@ -42,6 +42,23 @@ class CommentBox extends React.Component {
         this.setState({
           comments: update(comments, diff)
         })
+
+        if (typeof parentIndex !== 'undefined') {
+          this.updateStateComment(parentIndex, undefined, {replyError: false})
+        } else {
+          this.setState({
+            error: false
+          })
+        }
+      })
+      .fail(respone => {
+        if (typeof parentIndex !== 'undefined') {
+          this.updateStateComment(parentIndex, undefined, {replyError: true})
+        } else {
+          this.setState({
+            error: true
+          })
+        }
       })
   }
 
@@ -53,7 +70,13 @@ class CommentBox extends React.Component {
     }
 
     return api.comments.change(modifiedComment, comment.id)
-      .done(this.updateStateComment.bind(this, index, parentIndex))
+      .done(changed => {
+        this.updateStateComment(index, parentIndex, changed)
+        this.updateStateComment(index, parentIndex, {editError: false})
+      })
+      .fail(respone => {
+        this.updateStateComment(index, parentIndex, {editError: true})
+      })
   }
 
   handleCommentDelete (index, parentIndex) {

--- a/adhocracy4/comments/static/comments/CommentBox.jsx
+++ b/adhocracy4/comments/static/comments/CommentBox.jsx
@@ -126,7 +126,7 @@ class CommentBox extends React.Component {
         <div className="comment-box">
           <CommentForm subjectType={this.props.subjectType} subjectId={this.props.subjectId}
             onCommentSubmit={this.handleCommentSubmit.bind(this)} placeholder={django.gettext('Your comment here')}
-            rows="5" isReadOnly={this.props.isReadOnly} />
+            rows="5" isReadOnly={this.props.isReadOnly} error={this.state.error} handleErrorClick={this.hideNewError.bind(this)} />
           <div className="comment-list">
             <CommentList
               comments={this.state.comments}
@@ -134,6 +134,8 @@ class CommentBox extends React.Component {
               handleCommentSubmit={this.handleCommentSubmit.bind(this)}
               handleCommentModify={this.handleCommentModify.bind(this)}
               isReadOnly={this.props.isReadOnly}
+              handleReplyErrorClick={this.hideReplyError.bind(this)}
+              handleEditErrorClick={this.hideEditError.bind(this)}
             />
           </div>
         </div>

--- a/adhocracy4/comments/static/comments/CommentBox.jsx
+++ b/adhocracy4/comments/static/comments/CommentBox.jsx
@@ -96,6 +96,20 @@ class CommentBox extends React.Component {
       .done(this.updateStateComment.bind(this, index, parentIndex))
   }
 
+  hideNewError () {
+    this.setState({
+      error: false
+    })
+  }
+
+  hideReplyError (index, parentIndex) {
+    this.updateStateComment(index, parentIndex, {replyError: false})
+  }
+
+  hideEditError (index, parentIndex) {
+    this.updateStateComment(index, parentIndex, {editError: false})
+  }
+
   getChildContext () {
     return {
       isAuthenticated: this.props.isAuthenticated,

--- a/adhocracy4/comments/static/comments/CommentBox.jsx
+++ b/adhocracy4/comments/static/comments/CommentBox.jsx
@@ -15,6 +15,7 @@ class CommentBox extends React.Component {
       comments: this.props.comments
     }
   }
+
   updateStateComment (index, parentIndex, updatedComment) {
     var comments = this.state.comments
     var diff = {}
@@ -27,9 +28,10 @@ class CommentBox extends React.Component {
     comments = update(comments, diff)
     this.setState({ comments: comments })
   }
+
   handleCommentSubmit (comment, parentIndex) {
     return api.comments.add(comment)
-      .done(function (comment) {
+      .done(comment => {
         var comments = this.state.comments
         var diff = {}
         if (typeof parentIndex !== 'undefined') {
@@ -40,8 +42,9 @@ class CommentBox extends React.Component {
         this.setState({
           comments: update(comments, diff)
         })
-      }.bind(this))
+      })
   }
+
   handleCommentModify (modifiedComment, index, parentIndex) {
     var comments = this.state.comments
     var comment = comments[index]
@@ -52,6 +55,7 @@ class CommentBox extends React.Component {
     return api.comments.change(modifiedComment, comment.id)
       .done(this.updateStateComment.bind(this, index, parentIndex))
   }
+
   handleCommentDelete (index, parentIndex) {
     var comments = this.state.comments
     var comment = comments[index]
@@ -68,6 +72,7 @@ class CommentBox extends React.Component {
     return api.comments.delete(data, comment.id)
       .done(this.updateStateComment.bind(this, index, parentIndex))
   }
+
   getChildContext () {
     return {
       isAuthenticated: this.props.isAuthenticated,
@@ -76,6 +81,7 @@ class CommentBox extends React.Component {
       user_name: this.props.user_name
     }
   }
+
   render () {
     return (
       <div>
@@ -85,9 +91,13 @@ class CommentBox extends React.Component {
             onCommentSubmit={this.handleCommentSubmit.bind(this)} placeholder={django.gettext('Your comment here')}
             rows="5" isReadOnly={this.props.isReadOnly} />
           <div className="comment-list">
-            <CommentList comments={this.state.comments} handleCommentDelete={this.handleCommentDelete.bind(this)}
-              handleCommentSubmit={this.handleCommentSubmit.bind(this)} handleCommentModify={this.handleCommentModify.bind(this)}
-              isReadOnly={this.props.isReadOnly} />
+            <CommentList
+              comments={this.state.comments}
+              handleCommentDelete={this.handleCommentDelete.bind(this)}
+              handleCommentSubmit={this.handleCommentSubmit.bind(this)}
+              handleCommentModify={this.handleCommentModify.bind(this)}
+              isReadOnly={this.props.isReadOnly}
+            />
           </div>
         </div>
       </div>

--- a/adhocracy4/comments/static/comments/CommentBox.jsx
+++ b/adhocracy4/comments/static/comments/CommentBox.jsx
@@ -28,7 +28,7 @@ class CommentBox extends React.Component {
     this.setState({ comments: comments })
   }
   handleCommentSubmit (comment, parentIndex) {
-    api.comments.add(comment)
+    return api.comments.add(comment)
       .done(function (comment) {
         var comments = this.state.comments
         var diff = {}
@@ -49,7 +49,7 @@ class CommentBox extends React.Component {
       comment = comments[parentIndex].child_comments[index]
     }
 
-    api.comments.change(modifiedComment, comment.id)
+    return api.comments.change(modifiedComment, comment.id)
       .done(this.updateStateComment.bind(this, index, parentIndex))
   }
   handleCommentDelete (index, parentIndex) {
@@ -65,7 +65,7 @@ class CommentBox extends React.Component {
         objectPk: comment.object_pk
       }
     }
-    api.comments.delete(data, comment.id)
+    return api.comments.delete(data, comment.id)
       .done(this.updateStateComment.bind(this, index, parentIndex))
   }
   getChildContext () {

--- a/adhocracy4/comments/static/comments/CommentEditForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentEditForm.jsx
@@ -1,3 +1,5 @@
+var Alert = require('../../../static/Alert')
+
 var React = require('react')
 var PropTypes = require('prop-types')
 var django = require('django')
@@ -28,6 +30,9 @@ class CommentEditForm extends React.Component {
   render () {
     return (
       <form className="general-form" onSubmit={this.handleSubmit.bind(this)}>
+        {this.props.error &&
+          <Alert type="danger" message={django.gettext('Error!')} onClick={this.props.handleErrorClick} />
+        }
         <div className="form-group">
           <textarea rows={this.props.rows} className="form-control"
             placeholder={django.gettext('Your comment here')}

--- a/adhocracy4/comments/static/comments/CommentEditForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentEditForm.jsx
@@ -31,7 +31,7 @@ class CommentEditForm extends React.Component {
     return (
       <form className="general-form" onSubmit={this.handleSubmit.bind(this)}>
         {this.props.error &&
-          <Alert type="danger" message={django.gettext('Error!')} onClick={this.props.handleErrorClick} />
+          <Alert type="danger" message={django.gettext('Error while submitting your comment!')} onClick={this.props.handleErrorClick} />
         }
         <div className="form-group">
           <textarea rows={this.props.rows} className="form-control"

--- a/adhocracy4/comments/static/comments/CommentForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentForm.jsx
@@ -1,4 +1,5 @@
 var config = require('../../../static/config')
+var Alert = require('../../../static/Alert')
 
 var React = require('react')
 var PropTypes = require('prop-types')
@@ -36,6 +37,9 @@ class CommentForm extends React.Component {
     if (this.context.isAuthenticated && !this.props.isReadOnly) {
       return (
         <form className="general-form" onSubmit={this.handleSubmit.bind(this)}>
+          {this.props.error &&
+            <Alert type="danger" message={django.gettext('Error!')} onClick={this.props.handleErrorClick} />
+          }
           <div className="form-group">
             <textarea rows={this.props.rows} className="form-control"
               placeholder={django.gettext('Your comment here')}

--- a/adhocracy4/comments/static/comments/CommentForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentForm.jsx
@@ -10,9 +10,11 @@ class CommentForm extends React.Component {
 
     this.state = {comment: ''}
   }
+
   handleTextChange (e) {
     this.setState({comment: e.target.value})
   }
+
   handleSubmit (e) {
     e.preventDefault()
     var comment = this.state.comment.trim()
@@ -29,6 +31,7 @@ class CommentForm extends React.Component {
       this.setState({comment: ''})
     })
   }
+
   render () {
     if (this.context.isAuthenticated && !this.props.isReadOnly) {
       return (

--- a/adhocracy4/comments/static/comments/CommentForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentForm.jsx
@@ -38,7 +38,7 @@ class CommentForm extends React.Component {
       return (
         <form className="general-form" onSubmit={this.handleSubmit.bind(this)}>
           {this.props.error &&
-            <Alert type="danger" message={django.gettext('Error!')} onClick={this.props.handleErrorClick} />
+            <Alert type="danger" message={django.gettext('Error while submitting your comment!')} onClick={this.props.handleErrorClick} />
           }
           <div className="form-group">
             <textarea rows={this.props.rows} className="form-control"

--- a/adhocracy4/comments/static/comments/CommentForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentForm.jsx
@@ -25,8 +25,9 @@ class CommentForm extends React.Component {
         objectPk: this.props.subjectId,
         contentTypeId: this.props.subjectType
       }
-    }, this.props.parentIndex)
-    this.setState({comment: ''})
+    }, this.props.parentIndex).then(() => {
+      this.setState({comment: ''})
+    })
   }
   render () {
     if (this.context.isAuthenticated && !this.props.isReadOnly) {

--- a/adhocracy4/comments/static/comments/CommentList.jsx
+++ b/adhocracy4/comments/static/comments/CommentList.jsx
@@ -28,6 +28,10 @@ var CommentList = (props) => {
             userRating={comment.ratings.current_user_rating_value}
             userRatingId={comment.ratings.current_user_rating_id}
             isReadOnly={props.isReadOnly}
+            replyError={comment.replyError}
+            handleReplyErrorClick={props.handleReplyErrorClick}
+            editError={comment.editError}
+            handleEditErrorClick={props.handleEditErrorClick}
           >{comment.comment}</Comment>
         })
       }

--- a/adhocracy4/static/Alert.jsx
+++ b/adhocracy4/static/Alert.jsx
@@ -1,0 +1,21 @@
+var React = require('react')
+var django = require('django')
+
+const Alert = ({type, message, onClick}) => {
+  if (type) {
+    return (
+      <div className={`alert alert--${type}`} role="alert" onClick={onClick}>
+        <div className="l-wrapper">
+          {message}
+          <button className="alert__close" title={django.gettext('Close')}>
+            <i className="fa fa-times" aria-label={django.gettext('Close')} />
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return null
+}
+
+module.exports = Alert


### PR DESCRIPTION
This adds error messages when creating or editing comments fails. I tested it by stopping the server after I had loaded the page.

I am not all too happy with this PR. It does what it is supposed to be, but I found it hard to find my way around the comment code, simply because it is complex already. I hope I was able to refactor my additions to a point where review is possible.

Fixes #95