### PR TITLE
set next parameter when redirecting to login from js

### DIFF
--- a/adhocracy4/comments/static/comments/CommentForm.jsx
+++ b/adhocracy4/comments/static/comments/CommentForm.jsx
@@ -43,7 +43,7 @@ class CommentForm extends React.Component {
     } else if (!this.props.isReadOnly) {
       return (
         <div className="comments_login">
-          <a href={config.loginUrl}>{django.gettext('Please login to comment')}</a>
+          <a href={config.getLoginUrl()}>{django.gettext('Please login to comment')}</a>
         </div>
       )
     } else {

--- a/adhocracy4/ratings/static/ratings/react_ratings.jsx
+++ b/adhocracy4/ratings/static/ratings/react_ratings.jsx
@@ -56,7 +56,7 @@ class RatingBox extends React.Component {
   ratingUp (e) {
     e.preventDefault()
     if (this.props.authenticatedAs === null) {
-      window.location.href = config.loginUrl
+      window.location.href = config.getLoginUrl()
       return
     }
     if (this.props.isReadOnly) {
@@ -77,7 +77,7 @@ class RatingBox extends React.Component {
   ratingDown (e) {
     e.preventDefault()
     if (this.props.authenticatedAs === null) {
-      window.location.href = config.loginUrl
+      window.location.href = config.getLoginUrl()
       return
     }
     if (this.props.isReadOnly) {

--- a/adhocracy4/static/config.js
+++ b/adhocracy4/static/config.js
@@ -1,3 +1,10 @@
+var loginUrl = '/accounts/login'
+
+var getLoginUrl = function () {
+  let next = window.adhocracy4.getCurrentPath()
+  return loginUrl + '?next=' + encodeURIComponent(next)
+}
+
 module.exports = {
-  loginUrl: '/accounts/login'
+  getLoginUrl: getLoginUrl
 }


### PR DESCRIPTION
fixes #32

Note that `window.adhocracy4.getCurrentPath()` is used. In the default case, this just returns `window.location.path`. We need to be able to overwrite this for embedding in meinberlin.

This is breaking because `config.loginUrl` is removed.