### PR TITLE
Mn 2018 01 fix richtext field export errors

### DIFF
--- a/adhocracy4/exports/views.py
+++ b/adhocracy4/exports/views.py
@@ -84,6 +84,11 @@ class SimpleItemExportView(AbstractXlsxExportView,
         except TypeError:
             pass
 
+        # Return the get_field_display value for choice fields
+        get_field_display_method = getattr(
+            item, 'get_{}_display'.format(name), None)
+        if get_field_display_method and callable(get_field_display_method):
+            return get_field_display_method()
         # Finally try to get the fields data as a property
         return str(getattr(item, name, ''))
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,3 +13,4 @@ python-dateutil==2.6.1
 python-magic==0.4.15
 rules==1.2.1
 XlsxWriter==1.0.2
+lxml==4.1.1

--- a/tests/exports/test_export_view.py
+++ b/tests/exports/test_export_view.py
@@ -101,4 +101,4 @@ def test_item_text_cleanup(idea_factory, module, rf):
 
     view = IdeaExportView()
     rows = list(view.export_rows())
-    assert rows[0][1] == 'description'
+    assert rows[0][1] == 'description '


### PR DESCRIPTION
It seems to me that the RichTextField saves the data in ascii/html and not in utf8, therefore text from those fields is not exported correctly. Using lxml fixed the problem for me with excel. 

But I am not sure if there could be a better solution for this as lxml is quite huge and by adding it here we would add to all our projects. 