### PR TITLE
Escape html in feature name used for map popups

### DIFF
--- a/adhocracy4/maps/static/a4maps/map_display_points.js
+++ b/adhocracy4/maps/static/a4maps/map_display_points.js
@@ -2,6 +2,14 @@ var init = function () {
   var $ = window.jQuery
   var L = window.L
 
+  var escapeHtml = function (unsafe) {
+    // jQuery.text() escapes special chars as is documented at http://api.jquery.com/text/#text-function
+    // Alternatively a custom unsafe.replace(/&/g, '&amp;')... solution as described
+    // at https://stackoverflow.com/a/6234804 may be used. for example underscore.js uses a regexp based unescape.
+    // FIXME: this method should be moved to a global scope or made importable if used more then once
+    return $('<div>').text(unsafe).html()
+  }
+
   $('[data-map="display_points"]').each(function (i, e) {
     var polygon = JSON.parse(e.getAttribute('data-polygon'))
     var points = JSON.parse(e.getAttribute('data-points'))
@@ -85,7 +93,9 @@ var init = function () {
                               feature.properties.comments_count + ' <i class="fa fa-comment-o" aria-hidden="true"></i>' +
                               '</span>' +
                               '</div>' +
-                          '<div class="maps-popups-popup-name"><a href="' + feature.properties.url + '">' + feature.properties.name + '</a></div>'
+                          '<div class="maps-popups-popup-name">' +
+                              '<a href="' + feature.properties.url + '">' + escapeHtml(feature.properties.name) + '</a>' +
+                          '</div>'
         marker.bindPopup(popupContent, customOptions)
         return marker
       }

--- a/adhocracy4/maps/templatetags/maps_tags.py
+++ b/adhocracy4/maps/templatetags/maps_tags.py
@@ -33,7 +33,7 @@ def get_points(items):
         properties = {
             'name': item.name,
             'slug': item.slug,
-            'image':  image_url,
+            'image': image_url,
             'comments_count': comment_count,
             'positive_rating_count': positive_rating_count,
             'negative_rating_count': negative_rating_count,


### PR DESCRIPTION
An alternative would be to use something like:
```
function escapeHtml(unsafe) {
    return unsafe
         .replace(/&/g, "&amp;")
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;")
         .replace(/"/g, "&quot;")
         .replace(/'/g, "&#039;");
 }
```
a similiar solution is [used in underscore.js](https://github.com/jashkenas/underscore/blob/master/underscore.js#L1462)

i did not create the function as a contrib helper function, as the map_display_points.js is currently not handled by babel. if we need it somewhere else, we should move it to `adhocracy/static` and import it with babel. this would require to adapt our webpack scripts.

@fuzzylogic2000  @MagdaN @mkind 
are you okay with this fix? in addition i would like to merge the CSP PRs. and we can still think about sanitizing every user entered text field
