### PR TITLE
Fix setting up AUTO_FOLLOWABLES models

### DIFF
--- a/adhocracy4/follows/signals.py
+++ b/adhocracy4/follows/signals.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from django.conf import settings
 from django.db.models.signals import post_save
 
@@ -14,5 +15,5 @@ def autofollow_hook(instance, **kwargs):
             })
 
 
-for model in settings.A4_AUTO_FOLLOWABLES:
-    post_save.connect(autofollow_hook, model)
+for app, model in settings.A4_AUTO_FOLLOWABLES:
+    post_save.connect(autofollow_hook, apps.get_model(app, model))


### PR DESCRIPTION
Note that `Signal.connect` expects the model class as the sender
argument.

Altough while using e.g. `post_save` it also works with a string
`"apname.model"`. But this signature is not documented :( 