### PR TITLE
cached properties

### DIFF
--- a/adhocracy4/modules/models.py
+++ b/adhocracy4/modules/models.py
@@ -1,6 +1,7 @@
 from autoslug import AutoSlugField
 from django.db import models
 from django.core.urlresolvers import reverse
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4.models import base
@@ -52,15 +53,15 @@ class Module(models.Model):
             .active_phases() \
             .first()
 
-    @property
+    @cached_property
     def phases(self):
         return self.phase_set.all()
 
-    @property
+    @cached_property
     def future_phases(self):
         return self.phase_set.future_phases()
 
-    @property
+    @cached_property
     def past_phases(self):
         return self.phase_set.past_phases()
 

--- a/adhocracy4/projects/models.py
+++ b/adhocracy4/projects/models.py
@@ -12,9 +12,6 @@ from adhocracy4.models import base
 from adhocracy4 import transforms as html_transforms
 from adhocracy4.images import fields
 
-#XXXXXXXXxx
-cached_property = property
-
 
 class ProjectManager(models.Manager):
 
@@ -155,7 +152,7 @@ class Project(base.TimeStampedModel):
     def modules(self):
         return self.module_set.all()
 
-    @cached_property
+    @property
     def last_active_phase(self):
         """
         Return the last active phase.
@@ -192,17 +189,13 @@ class Project(base.TimeStampedModel):
             return last_active_phase
         return None
 
-    @cached_property
+    @property
     def days_left(self):
         """
         Return the number of days left in the currently active phase.
 
         Attention: This method is _deprecated_ as multiple phases may be
         active at the same time.
-
-        It's a cached property to workaround possibly unexpected day
-        counts when accessed two times when milliseconds before a
-        day change.
         """
         active_phase = self.active_phase
         if active_phase:
@@ -224,11 +217,11 @@ class Project(base.TimeStampedModel):
     def past_phases(self):
         return self.phases.past_phases()
 
-    @cached_property
+    @property
     def has_started(self):
         return self.phases.past_and_active_phases().exists()
 
-    @cached_property
+    @property
     def has_finished(self):
         return not self.phases.active_phases().exists()\
                and not self.phases.future_phases().exists()

--- a/tests/modules/test_module_models.py
+++ b/tests/modules/test_module_models.py
@@ -48,8 +48,10 @@ def test_last_active_phase(module, phase_factory):
     with freeze_time(phase1.start_date):
         assert module.last_active_phase == phase1
 
+    module = module.__class__.objects.get(pk=module.pk)
     with freeze_time(phase1.end_date):
         assert module.last_active_phase == phase1
 
+    module = module.__class__.objects.get(pk=module.pk)
     with freeze_time(phase2.end_date):
         assert module.last_active_phase == phase2

--- a/tests/modules/test_module_models.py
+++ b/tests/modules/test_module_models.py
@@ -44,7 +44,9 @@ def test_last_active_phase(module, phase_factory):
     with freeze_time(phase1.start_date - timedelta(minutes=1)):
         assert module.last_active_phase is None
 
+    # reinitialize module object
     module = module.__class__.objects.get(pk=module.pk)
+
     with freeze_time(phase1.start_date):
         assert module.last_active_phase == phase1
 

--- a/tests/modules/test_module_models.py
+++ b/tests/modules/test_module_models.py
@@ -43,9 +43,13 @@ def test_last_active_phase(module, phase_factory):
 
     with freeze_time(phase1.start_date - timedelta(minutes=1)):
         assert module.last_active_phase is None
+
+    module = module.__class__.objects.get(pk=module.pk)
     with freeze_time(phase1.start_date):
         assert module.last_active_phase == phase1
+
     with freeze_time(phase1.end_date):
         assert module.last_active_phase == phase1
+
     with freeze_time(phase2.end_date):
         assert module.last_active_phase == phase2


### PR DESCRIPTION
Ha! It does make a difference:
When viewing 4 projects in meinberlin there are 39 queries without this, with this changes it's "only" 30 queries.
As you can see in the changes for the test there is a slight change in behavior, that is that the value of a property may not change anymore when called multiple times, but I don't think we rely on that in the code.