### PR TITLE
Streamline app initialization

### DIFF
--- a/adhocracy4/actions/__init__.py
+++ b/adhocracy4/actions/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.actions.apps.ActionsConfig'

--- a/adhocracy4/actions/__init__.py
+++ b/adhocracy4/actions/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.actions.apps.ActionsConfig'
+default_app_config = 'adhocracy4.actions.apps.Config'

--- a/adhocracy4/actions/apps.py
+++ b/adhocracy4/actions/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 
 
-class ActionsConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.actions'
     label = 'a4actions'
 

--- a/adhocracy4/administrative_districts/__init__.py
+++ b/adhocracy4/administrative_districts/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.administrative_districts.apps.AdministrativeDistrictsConfig'
+default_app_config = 'adhocracy4.administrative_districts.apps.Config'

--- a/adhocracy4/administrative_districts/__init__.py
+++ b/adhocracy4/administrative_districts/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.administrative_districts.apps.AdministrativeDistrictsConfig'

--- a/adhocracy4/administrative_districts/apps.py
+++ b/adhocracy4/administrative_districts/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class AdministrativeDistrictsConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.administrative_districts'
     label = 'a4administrative_districts'

--- a/adhocracy4/categories/__init__.py
+++ b/adhocracy4/categories/__init__.py
@@ -2,6 +2,9 @@ from django.conf import settings
 from django.contrib.staticfiles.templatetags.staticfiles import static
 
 
+default_app_config = 'adhocracy4.categories.apps.CategoriesConfig'
+
+
 def has_icons(module):
     if not hasattr(settings, 'A4_CATEGORY_ICONS'):
         return False

--- a/adhocracy4/categories/__init__.py
+++ b/adhocracy4/categories/__init__.py
@@ -1,8 +1,7 @@
 from django.conf import settings
 from django.contrib.staticfiles.templatetags.staticfiles import static
 
-
-default_app_config = 'adhocracy4.categories.apps.CategoriesConfig'
+default_app_config = 'adhocracy4.categories.apps.Config'
 
 
 def has_icons(module):

--- a/adhocracy4/categories/apps.py
+++ b/adhocracy4/categories/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class CategoriesConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.categories'
     label = 'a4categories'

--- a/adhocracy4/ckeditor/__init__.py
+++ b/adhocracy4/ckeditor/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.ckeditor.apps.CKEditorConfig'
+default_app_config = 'adhocracy4.ckeditor.apps.Config'

--- a/adhocracy4/ckeditor/__init__.py
+++ b/adhocracy4/ckeditor/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.ckeditor.apps.CKEditorConfig'

--- a/adhocracy4/ckeditor/apps.py
+++ b/adhocracy4/ckeditor/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class CKEditorConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.ckeditor'
     label = 'a4ckeditor'

--- a/adhocracy4/comments/__init__.py
+++ b/adhocracy4/comments/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.comments.apps.CommentsConfig'
+default_app_config = 'adhocracy4.comments.apps.Config'

--- a/adhocracy4/comments/__init__.py
+++ b/adhocracy4/comments/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.comments.apps.CommentsConfig'

--- a/adhocracy4/comments/apps.py
+++ b/adhocracy4/comments/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 
 
-class CommentsConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.comments'
     label = 'a4comments'
 

--- a/adhocracy4/dashboard/__init__.py
+++ b/adhocracy4/dashboard/__init__.py
@@ -8,7 +8,7 @@ from .components.forms import ModuleFormSetComponent
 from .components.forms import ProjectFormComponent
 
 
-default_app_config = 'adhocracy4.dashboard.apps.DashboardConfig'
+default_app_config = 'adhocracy4.dashboard.apps.Config'
 
 __all__ = ['components', 'DashboardComponent',
            'ModuleFormComponent', 'ModuleFormSetComponent',

--- a/adhocracy4/dashboard/__init__.py
+++ b/adhocracy4/dashboard/__init__.py
@@ -8,6 +8,8 @@ from .components.forms import ModuleFormSetComponent
 from .components.forms import ProjectFormComponent
 
 
+default_app_config = 'adhocracy4.dashboard.apps.DashboardConfig'
+
 __all__ = ['components', 'DashboardComponent',
            'ModuleFormComponent', 'ModuleFormSetComponent',
            'ProjectFormComponent',

--- a/adhocracy4/dashboard/apps.py
+++ b/adhocracy4/dashboard/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 
 
-class DashboardConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.dashboard'
     label = 'a4dashboard'
 

--- a/adhocracy4/filters/__init__.py
+++ b/adhocracy4/filters/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.filters.apps.FiltersConfig'
+default_app_config = 'adhocracy4.filters.apps.Config'

--- a/adhocracy4/filters/__init__.py
+++ b/adhocracy4/filters/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.filters.apps.FiltersConfig'

--- a/adhocracy4/filters/apps.py
+++ b/adhocracy4/filters/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class FiltersConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.filters'
     label = 'a4filters'

--- a/adhocracy4/follows/__init__.py
+++ b/adhocracy4/follows/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.follows.apps.FollowsConfig'

--- a/adhocracy4/follows/__init__.py
+++ b/adhocracy4/follows/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.follows.apps.FollowsConfig'
+default_app_config = 'adhocracy4.follows.apps.Config'

--- a/adhocracy4/follows/apps.py
+++ b/adhocracy4/follows/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 
 
-class FollowsConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.follows'
     label = 'a4follows'
 

--- a/adhocracy4/forms/__init__.py
+++ b/adhocracy4/forms/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.forms.apps.FormsConfig'
+default_app_config = 'adhocracy4.forms.apps.Config'

--- a/adhocracy4/forms/__init__.py
+++ b/adhocracy4/forms/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.forms.apps.FormsConfig'

--- a/adhocracy4/forms/apps.py
+++ b/adhocracy4/forms/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class FormsConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.forms'
     label = 'a4forms'

--- a/adhocracy4/images/__init__.py
+++ b/adhocracy4/images/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.images.apps.ImagesConfig'
+default_app_config = 'adhocracy4.images.apps.Config'

--- a/adhocracy4/images/__init__.py
+++ b/adhocracy4/images/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.images.apps.ImagesConfig'

--- a/adhocracy4/images/apps.py
+++ b/adhocracy4/images/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 
 
-class ImagesConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.images'
     label = 'a4images'
 

--- a/adhocracy4/labels/__init__.py
+++ b/adhocracy4/labels/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.labels.apps.LabelsConfig'

--- a/adhocracy4/labels/__init__.py
+++ b/adhocracy4/labels/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.labels.apps.LabelsConfig'
+default_app_config = 'adhocracy4.labels.apps.Config'

--- a/adhocracy4/labels/apps.py
+++ b/adhocracy4/labels/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class LabelsConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.labels'
     label = 'a4labels'

--- a/adhocracy4/maps/__init__.py
+++ b/adhocracy4/maps/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.maps.apps.MapsConfig'

--- a/adhocracy4/maps/__init__.py
+++ b/adhocracy4/maps/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.maps.apps.MapsConfig'
+default_app_config = 'adhocracy4.maps.apps.Config'

--- a/adhocracy4/maps/apps.py
+++ b/adhocracy4/maps/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class MapsConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.maps'
     label = 'a4maps'

--- a/adhocracy4/modules/__init__.py
+++ b/adhocracy4/modules/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.modules.apps.ModulesConfig'

--- a/adhocracy4/modules/__init__.py
+++ b/adhocracy4/modules/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.modules.apps.ModulesConfig'
+default_app_config = 'adhocracy4.modules.apps.Config'

--- a/adhocracy4/modules/apps.py
+++ b/adhocracy4/modules/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class ModulesConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.modules'
     label = 'a4modules'

--- a/adhocracy4/organisations/__init__.py
+++ b/adhocracy4/organisations/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.organisations.apps.OrganisationsConfig'

--- a/adhocracy4/organisations/__init__.py
+++ b/adhocracy4/organisations/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.organisations.apps.OrganisationsConfig'
+default_app_config = 'adhocracy4.organisations.apps.Config'

--- a/adhocracy4/organisations/apps.py
+++ b/adhocracy4/organisations/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class OrganisationsConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.organisations'
     label = 'a4organisations'

--- a/adhocracy4/phases/__init__.py
+++ b/adhocracy4/phases/__init__.py
@@ -1,3 +1,5 @@
 from .contents import content, PhaseContent
 
+default_app_config = 'adhocracy4.phases.apps.PhasesConfig'
+
 __all__ = ['content', 'PhaseContent']

--- a/adhocracy4/phases/__init__.py
+++ b/adhocracy4/phases/__init__.py
@@ -1,5 +1,5 @@
 from .contents import content, PhaseContent
 
-default_app_config = 'adhocracy4.phases.apps.PhasesConfig'
+default_app_config = 'adhocracy4.phases.apps.Config'
 
 __all__ = ['content', 'PhaseContent']

--- a/adhocracy4/phases/apps.py
+++ b/adhocracy4/phases/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 
 
-class PhasesConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.phases'
     label = 'a4phases'
 

--- a/adhocracy4/polls/__init__.py
+++ b/adhocracy4/polls/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.polls.apps.PollsConfig'

--- a/adhocracy4/polls/__init__.py
+++ b/adhocracy4/polls/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.polls.apps.PollsConfig'
+default_app_config = 'adhocracy4.polls.apps.Config'

--- a/adhocracy4/polls/apps.py
+++ b/adhocracy4/polls/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class PollsConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.polls'
     label = 'a4polls'

--- a/adhocracy4/polls/phases.py
+++ b/adhocracy4/polls/phases.py
@@ -8,7 +8,7 @@ from . import views
 
 
 class VotingPhase(phases.PhaseContent):
-    app = apps.PollsConfig.label
+    app = apps.Config.label
     phase = 'voting'
     view = views.PollDetailView
 

--- a/adhocracy4/projects/__init__.py
+++ b/adhocracy4/projects/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.projects.apps.ProjectsConfig'

--- a/adhocracy4/projects/__init__.py
+++ b/adhocracy4/projects/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.projects.apps.ProjectsConfig'
+default_app_config = 'adhocracy4.projects.apps.Config'

--- a/adhocracy4/projects/apps.py
+++ b/adhocracy4/projects/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class ProjectsConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.projects'
     label = 'a4projects'

--- a/adhocracy4/ratings/__init__.py
+++ b/adhocracy4/ratings/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.ratings.apps.RatingsConfig'

--- a/adhocracy4/ratings/__init__.py
+++ b/adhocracy4/ratings/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.ratings.apps.RatingsConfig'
+default_app_config = 'adhocracy4.ratings.apps.Config'

--- a/adhocracy4/ratings/apps.py
+++ b/adhocracy4/ratings/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 
 
-class RatingsConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.ratings'
     label = 'a4ratings'
 

--- a/adhocracy4/reports/__init__.py
+++ b/adhocracy4/reports/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.reports.apps.ReportsConfig'
+default_app_config = 'adhocracy4.reports.apps.Config'

--- a/adhocracy4/reports/__init__.py
+++ b/adhocracy4/reports/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.reports.apps.ReportsConfig'

--- a/adhocracy4/reports/apps.py
+++ b/adhocracy4/reports/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class ReportsConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.reports'
     label = 'a4reports'

--- a/adhocracy4/rules/__init__.py
+++ b/adhocracy4/rules/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'adhocracy4.rules.apps.RulesConfig'

--- a/adhocracy4/rules/__init__.py
+++ b/adhocracy4/rules/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'adhocracy4.rules.apps.RulesConfig'
+default_app_config = 'adhocracy4.rules.apps.Config'

--- a/adhocracy4/rules/apps.py
+++ b/adhocracy4/rules/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class RulesConfig(AppConfig):
+class Config(AppConfig):
     name = 'adhocracy4.rules'
     label = 'a4rules'

--- a/tests/apps/ideas/__init__.py
+++ b/tests/apps/ideas/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'tests.apps.ideas.apps.Config'

--- a/tests/apps/ideas/apps.py
+++ b/tests/apps/ideas/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class IdeasConfig(AppConfig):
+class Config(AppConfig):
     name = 'tests.apps.ideas'
     label = 'a4test_ideas'

--- a/tests/apps/locations/__init__.py
+++ b/tests/apps/locations/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'tests.apps.locations.apps.Config'

--- a/tests/apps/locations/apps.py
+++ b/tests/apps/locations/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 
 
-class LocationsConfig(AppConfig):
+class Config(AppConfig):
     """A simple item locatable in a map."""
     name = 'tests.apps.locations'
     label = 'a4test_locations'

--- a/tests/apps/questions/__init__.py
+++ b/tests/apps/questions/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'tests.apps.questions.apps.Config'

--- a/tests/apps/questions/apps.py
+++ b/tests/apps/questions/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 
 
-class QuestionsConfig(AppConfig):
+class Config(AppConfig):
     """A simple question collection app for testing."""
     name = 'tests.apps.questions'
     label = 'a4test_questions'

--- a/tests/apps/questions/phases.py
+++ b/tests/apps/questions/phases.py
@@ -4,7 +4,7 @@ from . import apps, models, views
 
 
 class AskPhase(phases.PhaseContent):
-    app = apps.QuestionsConfig.label
+    app = apps.Config.label
     phase = 'ask'
     view = views.QuestionList
 
@@ -22,7 +22,7 @@ phases.content.register(AskPhase())
 
 
 class RatePhase(phases.PhaseContent):
-    app = apps.QuestionsConfig.label
+    app = apps.Config.label
     phase = 'rate'
     view = views.QuestionList
 

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -27,39 +27,39 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = (
     # adhocracy4 base apps
-    'adhocracy4.organisations.apps.OrganisationsConfig',
-    'adhocracy4.projects.apps.ProjectsConfig',
-    'adhocracy4.modules.apps.ModulesConfig',
-    'adhocracy4.phases.apps.PhasesConfig',
-    'adhocracy4.reports.apps.ReportsConfig',
-    'adhocracy4.comments.apps.CommentsConfig',
-    'adhocracy4.maps.apps.MapsConfig',
-    'adhocracy4.actions.apps.ActionsConfig',
-    'adhocracy4.follows.apps.FollowsConfig',
-    'adhocracy4.filters.apps.FiltersConfig',
-    'adhocracy4.forms.apps.FormsConfig',
-    'adhocracy4.rules.apps.RulesConfig',
-    'adhocracy4.dashboard.apps.DashboardConfig',
-    'adhocracy4.polls.apps.PollsConfig',
-    'adhocracy4.administrative_districts.apps.AdministrativeDistrictsConfig',
+    'adhocracy4.organisations',
+    'adhocracy4.projects',
+    'adhocracy4.modules',
+    'adhocracy4.phases',
+    'adhocracy4.reports',
+    'adhocracy4.comments',
+    'adhocracy4.maps',
+    'adhocracy4.actions',
+    'adhocracy4.follows',
+    'adhocracy4.filters',
+    'adhocracy4.forms',
+    'adhocracy4.rules',
+    'adhocracy4.dashboard',
+    'adhocracy4.polls',
+    'adhocracy4.administrative_districts',
 
     # adhocrayc4 generic apps
-    'adhocracy4.ratings.apps.RatingsConfig',
-    'adhocracy4.categories.apps.CategoriesConfig',
-    'adhocracy4.labels.apps.LabelsConfig',
+    'adhocracy4.ratings',
+    'adhocracy4.categories',
+    'adhocracy4.labels',
 
     # adhocracy4 helper apps
-    'adhocracy4.ckeditor.apps.CKEditorConfig',
-    'adhocracy4.images.apps.ImagesConfig',
+    'adhocracy4.ckeditor',
+    'adhocracy4.images',
 
     # test apps
-    'tests.apps.questions.apps.QuestionsConfig',
-    'tests.apps.locations.apps.LocationsConfig',
-    'tests.apps.ideas.apps.IdeasConfig',
+    'tests.apps.questions',
+    'tests.apps.locations',
+    'tests.apps.ideas',
 
     # mandatory third party apps
     'easy_thumbnails',
-    'rules.apps.AutodiscoverRulesConfig',
+    'rules',
     'background_task',
 
     'django.contrib.admin',

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -59,7 +59,7 @@ INSTALLED_APPS = (
 
     # mandatory third party apps
     'easy_thumbnails',
-    'rules',
+    'rules.apps.AutodiscoverRulesConfig',
     'background_task',
 
     'django.contrib.admin',


### PR DESCRIPTION
This allows to initialize apps just from their folder name,
e.g. `adhocracy4.actions` instead of `adhocracy4.actions.apps.ActionsConfig`
It makes usage more intuitive, brings us in line with common practices
and avoids bugs in certain cases (background tasks).

~~This change should not brake the existing initialization, therefore
staying backward compatible.~~