### PR TITLE
ratings: fix crash on double creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 /venv
 /pip-selfcheck.json
 
+# Node
+node_modules
+package-lock.json
+
 # dev
 .idea/
 

--- a/adhocracy4/ratings/api.py
+++ b/adhocracy4/ratings/api.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django_filters import rest_framework as filters
 from rest_framework import mixins, viewsets
 from rest_framework.response import Response
+from rest_framework.serializers import ValidationError
 
 from adhocracy4.api.mixins import ContentTypeMixin
 from adhocracy4.api.permissions import ViewSetRulesPermission
@@ -24,6 +25,11 @@ class RatingViewSet(mixins.CreateModelMixin,
     content_type_filter = settings.A4_RATEABLES
 
     def perform_create(self, serializer):
+        queryset = Rating.objects.filter(content_type_id=self.content_type.pk,
+                                         creator=self.request.user,
+                                         object_pk=self.content_object.pk)
+        if queryset.exists():
+            raise ValidationError(queryset[0].pk)
         serializer.save(
             content_object=self.content_object,
             creator=self.request.user

--- a/adhocracy4/ratings/static/ratings/react_ratings.jsx
+++ b/adhocracy4/ratings/static/ratings/react_ratings.jsx
@@ -12,7 +12,7 @@ class RatingBox extends React.Component {
     this.state = {
       positiveRatings: this.props.positiveRatings,
       negativeRatings: this.props.negativeRatings,
-      userHasRatingd: this.props.userRating !== null,
+      userHasRating: this.props.userRating !== null,
       userRating: this.props.userRating,
       userRatingId: this.props.userRatingId
     }
@@ -24,15 +24,27 @@ class RatingBox extends React.Component {
         contentTypeId: this.props.contentType
       },
       value: number
-    }).done(function (data) {
-      this.setState({
-        positiveRatings: data.meta_info.positive_ratings_on_same_object,
-        negativeRatings: data.meta_info.negative_ratings_on_same_object,
-        userRating: data.meta_info.user_rating_on_same_object_value,
-        userHasRatingd: true,
-        userRatingId: data.id
-      })
-    }.bind(this))
+    })
+      .done(function (data) {
+        this.setState({
+          positiveRatings: data.meta_info.positive_ratings_on_same_object,
+          negativeRatings: data.meta_info.negative_ratings_on_same_object,
+          userRating: data.meta_info.user_rating_on_same_object_value,
+          userHasRating: true,
+          userRatingId: data.id
+        })
+      }.bind(this))
+      .fail(function (jqXhr) {
+        if (jqXhr.status === 400 &&
+           jqXhr.responseJSON.length === 1 &&
+           Number.isInteger(parseInt(jqXhr.responseJSON[0]))) {
+          this.setState({
+            userHasRating: true,
+            userRatingId: jqXhr.responseJSON[0]
+          })
+          this.handleRatingModify(number, this.state.userRatingId)
+        }
+      }.bind(this))
   }
   handleRatingModify (number, id) {
     api.rating.change({
@@ -62,7 +74,7 @@ class RatingBox extends React.Component {
     if (this.props.isReadOnly) {
       return
     }
-    if (this.state.userHasRatingd) {
+    if (this.state.userHasRating) {
       var number
       if (this.state.userRating === 1) {
         number = 0
@@ -83,7 +95,7 @@ class RatingBox extends React.Component {
     if (this.props.isReadOnly) {
       return
     }
-    if (this.state.userHasRatingd) {
+    if (this.state.userHasRating) {
       var number
       if (this.state.userRating === -1) {
         number = 0


### PR DESCRIPTION
When a user has two tabs with the same page open and rates an item
in both of them, this will crash in the second tab if the user
has not previously rated the item before page load.

The reason is that we decide based on information from page load
whether we call 'create' or 'update' of the rating. If we call
'create' twice, it crashes.

This patch fixes the issue by making the API check whether a
rating exists already and returning the corresponding ID if
it is the case. The frontend again uses the ID to issue
an 'update' request.

This requires an additional roundtrip to the user, but keeps
the internal logic as simple as possible.

Fixes #293