### PR TITLE
tests: make helpers.py use timezone.now

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,12 +1,12 @@
-from datetime import datetime, timedelta
-
 from contextlib import contextmanager
+from datetime import timedelta
+from django.utils import timezone
 from freezegun import freeze_time
 
 
 @contextmanager
 def active_phase(module, phase_type):
-    now = datetime.now()
+    now = timezone.now()
     phase = module.phase_set.create(
         start_date=now,
         end_date=now + timedelta(days=1),


### PR DESCRIPTION
This fixes all but one warning concerning naive datetime