### PR TITLE
add progress of active phase as property to project

### DIFF
--- a/adhocracy4/projects/models.py
+++ b/adhocracy4/projects/models.py
@@ -266,6 +266,21 @@ class Project(ProjectContactDetailMixin,
             return time_delta.days
         return None
 
+    @property
+    def active_phase_progress(self):
+        """
+        Return the progress of the currently active phase in percent.
+
+        Attention: This method is _deprecated_ as multiple phases may be
+        active at the same time.
+        """
+        active_phase = self.active_phase
+        if active_phase:
+            time_gone = timezone.now() - active_phase.start_date
+            total_time = active_phase.end_date - active_phase.start_date
+            return round(time_gone / total_time * 100)
+        return None
+
     @cached_property
     def phases(self):
         from adhocracy4.phases import models as phase_models


### PR DESCRIPTION
As the days left are also a property and we might need the percentage elsewhere, it made sense (to me) to add it here.
But we also need something like https://github.com/liqd/a4-opin/blob/master/euth/projects/templatetags/time_delta_tags.py in meinBerlin. I am unsure where or how to add that, though. we have the days_left in the properties, but these are very coarse (because hours, minutes and seconds of timezone.now are set to zero). In meinBerlin we want days, hours and minutes and need that in the storefront and the participation overview. I don't know how to add the whole thing into the properties, because we might need to do translations with sentences. We could only add seconds_left and add the other stuff in the respective project, but that also doesn't seem too sensible. ???!!