### PR TITLE
polls: fix crash if poll wasn't found

### DIFF
--- a/adhocracy4/polls/views.py
+++ b/adhocracy4/polls/views.py
@@ -36,8 +36,9 @@ class PollDetailView(ProjectMixin,
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['question_list'] = \
-            self.object.questions.annotate_vote_count().all()
+        if self.object is not None:
+            context['question_list'] = \
+                self.object.questions.annotate_vote_count().all()
         return context
 
     def get_permission_object(self):


### PR DESCRIPTION
In the `get` method, the 404 exeption handler first sets `self.object = None`
and then calls `self.get_context_data`, which doesn't expect `self.object`
to be None. Add a check for that case.

Fixes https://sentry.liqd.net/sentry/opin-prod/issues/182/