### PR TITLE
Update to Django 2.2 lts

### DIFF
--- a/adhocracy4/api/routers.py
+++ b/adhocracy4/api/routers.py
@@ -16,8 +16,8 @@ class CustomRouterMixin():
 class ContentTypeRouterMixin(CustomRouterMixin):
 
     prefix_regex = (
-        'contenttypes/(?P<content_type>[\d]+)/'
-        'objects/(?P<object_pk>[\d]+)/{prefix}'
+        r'contenttypes/(?P<content_type>[\d]+)/'
+        r'objects/(?P<object_pk>[\d]+)/{prefix}'
     )
 
 
@@ -32,7 +32,7 @@ class ContentTypeDefaultRouter(ContentTypeRouterMixin, routers.DefaultRouter):
 class ModuleRouterMixin(CustomRouterMixin):
 
     prefix_regex = (
-        'modules/(?P<module_pk>[\d]+)/{prefix}'
+        r'modules/(?P<module_pk>[\d]+)/{prefix}'
     )
 
 
@@ -47,7 +47,7 @@ class ModuleDefaultRouter(ModuleRouterMixin, routers.DefaultRouter):
 class OrganisationRouterMixin(CustomRouterMixin):
 
     prefix_regex = (
-        'organisations/(?P<organisation_pk>[\d]+)/{prefix}'
+        r'organisations/(?P<organisation_pk>[\d]+)/{prefix}'
     )
 
 

--- a/adhocracy4/categories/__init__.py
+++ b/adhocracy4/categories/__init__.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 
 default_app_config = 'adhocracy4.categories.apps.Config'
 

--- a/adhocracy4/comments/api.py
+++ b/adhocracy4/comments/api.py
@@ -23,7 +23,7 @@ class CommentViewSet(mixins.CreateModelMixin,
     serializer_class = ThreadSerializer
     permission_classes = (ViewSetRulesPermission,)
     filter_backends = (filters.DjangoFilterBackend,)
-    filter_fields = ('object_pk', 'content_type')
+    filterset_fields = ('object_pk', 'content_type')
     content_type_filter = settings.A4_COMMENTABLES
 
     def perform_create(self, serializer):

--- a/adhocracy4/comments/models.py
+++ b/adhocracy4/comments/models.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib.contenttypes.fields import (GenericForeignKey,
                                                 GenericRelation)
 from django.contrib.contenttypes.models import ContentType
@@ -6,7 +5,6 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4 import transforms
-from adhocracy4.generics import models_to_limit
 from adhocracy4.models import base
 from adhocracy4.ratings import models as rating_models
 
@@ -17,8 +15,7 @@ class Comment(base.UserGeneratedContentModel):
 
     content_type = models.ForeignKey(
         ContentType,
-        on_delete=models.CASCADE,
-        limit_choices_to=models_to_limit(settings.A4_COMMENTABLES)
+        on_delete=models.CASCADE
     )
     object_pk = models.PositiveIntegerField()
     content_object = GenericForeignKey(

--- a/adhocracy4/dashboard/views.py
+++ b/adhocracy4/dashboard/views.py
@@ -2,7 +2,7 @@ from django.apps import apps
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.messages.views import SuccessMessageMixin
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _

--- a/adhocracy4/exports/mixins.py
+++ b/adhocracy4/exports/mixins.py
@@ -39,7 +39,8 @@ class ExportModelFieldsMixin(VirtualFieldMixin):
 
         for field in fields:
             if field.concrete \
-                    and not (field.one_to_one and field.rel.parent_link) \
+                    and not (field.one_to_one
+                             and field.remote_field.parent_link) \
                     and field.name not in exclude \
                     and field.name not in virtual:
                 virtual[field.name] = str(field.verbose_name)

--- a/adhocracy4/follows/api.py
+++ b/adhocracy4/follows/api.py
@@ -18,7 +18,7 @@ class FollowViewSet(AllowPUTAsCreateMixin,
     serializer_class = FollowSerializer
     permission_classes = (permissions.IsAuthenticated,)
     filter_backends = (filters.DjangoFilterBackend,)
-    filter_fields = ('enabled', )
+    filterset_fields = ('enabled', )
 
     def get_queryset(self):
         return self.queryset.filter(creator=self.request.user)

--- a/adhocracy4/modules/models.py
+++ b/adhocracy4/modules/models.py
@@ -1,6 +1,6 @@
 from autoslug import AutoSlugField
 from django.db import models
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 

--- a/adhocracy4/polls/routers.py
+++ b/adhocracy4/polls/routers.py
@@ -6,7 +6,7 @@ from adhocracy4.api.routers import CustomRouterMixin
 class QuestionRouterMixin(CustomRouterMixin):
 
     prefix_regex = (
-        'polls/question/(?P<question_pk>[\d]+)/{prefix}'
+        r'polls/question/(?P<question_pk>[\d]+)/{prefix}'
     )
 
 

--- a/adhocracy4/polls/templatetags/react_polls.py
+++ b/adhocracy4/polls/templatetags/react_polls.py
@@ -18,14 +18,16 @@ def react_polls(context, question):
 
     return format_html(
         '<div data-a4-widget="polls" data-question="{question}"></div>',
-        question=JSONRenderer().render(question_serializer.data)
+        question=JSONRenderer()
+        .render(question_serializer.data)
+        .decode("utf-8")
     )
 
 
 @register.simple_tag
 def react_poll_form(poll, reload_on_success=False):
     serializer = serializers.PollSerializer(poll)
-    data_poll = JSONRenderer().render(serializer.data)
+    data_poll = JSONRenderer().render(serializer.data).decode("utf-8")
     reload_on_success = json.dumps(reload_on_success)
 
     return format_html(

--- a/adhocracy4/projects/models.py
+++ b/adhocracy4/projects/models.py
@@ -2,7 +2,7 @@ from autoslug import AutoSlugField
 from ckeditor_uploader.fields import RichTextUploadingField
 from django.conf import settings
 from django.contrib.auth.models import Group
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.validators import RegexValidator
 from django.db import models
 from django.utils import timezone

--- a/adhocracy4/ratings/api.py
+++ b/adhocracy4/ratings/api.py
@@ -21,7 +21,7 @@ class RatingViewSet(mixins.CreateModelMixin,
     serializer_class = RatingSerializer
     permission_classes = (ViewSetRulesPermission,)
     filter_backends = (filters.DjangoFilterBackend,)
-    filter_fields = ('object_pk', 'content_type')
+    filterset_fields = ('object_pk', 'content_type')
     content_type_filter = settings.A4_RATEABLES
 
     def perform_create(self, serializer):

--- a/adhocracy4/ratings/models.py
+++ b/adhocracy4/ratings/models.py
@@ -1,11 +1,9 @@
-from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 
 from adhocracy4.models.base import UserGeneratedContentModel
-from adhocracy4.generics import models_to_limit
 
 
 class Rating(UserGeneratedContentModel):
@@ -15,8 +13,7 @@ class Rating(UserGeneratedContentModel):
 
     content_type = models.ForeignKey(
         ContentType,
-        on_delete=models.CASCADE,
-        limit_choices_to=models_to_limit(settings.A4_RATEABLES)
+        on_delete=models.CASCADE
     )
     object_pk = models.PositiveIntegerField()
     content_object = GenericForeignKey(

--- a/adhocracy4/reports/models.py
+++ b/adhocracy4/reports/models.py
@@ -1,9 +1,7 @@
-from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
-from adhocracy4.generics import models_to_limit
 from adhocracy4.models import base
 
 
@@ -11,8 +9,7 @@ class Report(base.UserGeneratedContentModel):
 
     content_type = models.ForeignKey(
         ContentType,
-        on_delete=models.CASCADE,
-        limit_choices_to=models_to_limit(settings.A4_REPORTABLES)
+        on_delete=models.CASCADE
     )
     object_pk = models.PositiveIntegerField()
     content_object = GenericForeignKey(

--- a/adhocracy4/rules/discovery.py
+++ b/adhocracy4/rules/discovery.py
@@ -1,6 +1,5 @@
 import rules
 from django.contrib.auth.models import AnonymousUser
-from django.utils.deprecation import CallableTrue
 
 
 class NormalUser(AnonymousUser):
@@ -16,7 +15,7 @@ class NormalUser(AnonymousUser):
 
     @property
     def is_authenticated(self):
-        return CallableTrue
+        return True
 
     def would_have_perm(self, perm, obj):
         return rules.has_perm(perm, self, obj)

--- a/adhocracy4/test/helpers.py
+++ b/adhocracy4/test/helpers.py
@@ -5,7 +5,7 @@ from unittest import mock
 from urllib.parse import urlparse
 
 from django.conf import settings
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from django.template import Context, Template
 from easy_thumbnails.files import get_thumbnailer
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,6 @@ django-autoslug==1.9.4
 django-background-tasks==1.2.0
 django-ckeditor==5.7.1
 django-filter==2.1.0
-django-multiselectfield==0.1.8
 django-widget-tweaks==1.4.3
 djangorestframework==3.9.4
 easy-thumbnails==2.6
@@ -15,3 +14,6 @@ python-dateutil==2.8.0
 python-magic==0.4.15
 rules==2.0.1
 XlsxWriter==1.1.5
+
+# Project is currently unmaintained. Use our own fork in the meantime
+git+git://github.com/liqd/django-multiselectfield.git@v0.1.9#egg=django-multiselectfield==0.1.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,17 +1,17 @@
-bleach==2.1.4
-Django==1.11.21 # pyup: <2.0
-django-allauth==0.35.0
-django-autoslug==1.9.3
-django-background-tasks==1.1.13
-django-multiselectfield==0.1.8
-django-ckeditor==5.4.0
+bleach==3.1.0
+Django==2.2.1 # pyup: <2.3
+django-allauth==0.39.1
+django-autoslug==1.9.4
+django-background-tasks==1.2.0
+django-ckeditor==5.7.1
 django-filter==2.1.0
-django-widget-tweaks==1.4.1
+django-multiselectfield==0.1.8
+django-widget-tweaks==1.4.3
 djangorestframework==3.9.4
-easy-thumbnails==2.5
+easy-thumbnails==2.6
 html5lib==1.0.1
 jsonfield==2.0.2
-python-dateutil==2.7.0
+python-dateutil==2.8.0
 python-magic==0.4.15
-rules==1.3
-XlsxWriter==1.0.2
+rules==2.0.1
+XlsxWriter==1.1.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,10 @@
 -r base.txt
-factory-boy==2.11.1
-Faker==0.8.11
+factory-boy==2.12.0
+Faker==1.0.7
 flake8==3.7.7
 freezegun==0.3.11
-isort==4.3.15
-pytest==4.3.0
-pytest-cov==2.6.1
-pytest-django==3.4.8
+isort==4.3.20
+pytest==4.6.2
+pytest-cov==2.7.1
+pytest-django==3.5.0
 pytest-factoryboy==2.0.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,11 +1,10 @@
 -r base.txt
-django-autofixture==0.12.1
-factory-boy==2.10.0
+factory-boy==2.11.1
 Faker==0.8.11
-flake8==3.5.0
-freezegun==0.3.10
-isort==4.3.4
-pytest==3.4.2
-pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest-factoryboy==2.0.1
+flake8==3.7.7
+freezegun==0.3.11
+isort==4.3.15
+pytest==4.3.0
+pytest-cov==2.6.1
+pytest-django==3.4.8
+pytest-factoryboy==2.0.2

--- a/tests/apps/locations/migrations/0001_initial.py
+++ b/tests/apps/locations/migrations/0001_initial.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Location',
             fields=[
-                ('item_ptr', models.OneToOneField(primary_key=True, serialize=False, auto_created=True, parent_link=True, to='a4modules.Item')),
+                ('item_ptr', models.OneToOneField(primary_key=True, serialize=False, auto_created=True, parent_link=True, to='a4modules.Item', on_delete=models.CASCADE)),
                 ('slug', autoslug.fields.AutoSlugField(unique=True, editable=False, populate_from='name')),
                 ('name', models.CharField(max_length=120)),
                 ('point', adhocracy4.maps.fields.PointField()),

--- a/tests/apps/organisations/models.py
+++ b/tests/apps/organisations/models.py
@@ -1,7 +1,7 @@
 from autoslug import AutoSlugField
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 
 

--- a/tests/apps/questions/migrations/0001_initial.py
+++ b/tests/apps/questions/migrations/0001_initial.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Question',
             fields=[
-                ('item_ptr', models.OneToOneField(serialize=False, primary_key=True, to='a4modules.Item', auto_created=True, parent_link=True)),
+                ('item_ptr', models.OneToOneField(serialize=False, primary_key=True, to='a4modules.Item', auto_created=True, parent_link=True, on_delete=models.CASCADE)),
                 ('text', models.CharField(max_length=120, default='Can i haz cheezburger, pls?')),
             ],
             options={

--- a/tests/comments/test_api.py
+++ b/tests/comments/test_api.py
@@ -1,6 +1,6 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework import status
 
 from tests.apps.questions.models import Question

--- a/tests/dashboard/test_views.py
+++ b/tests/dashboard/test_views.py
@@ -1,5 +1,5 @@
 import pytest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from adhocracy4.projects.models import Project
 from adhocracy4.test.helpers import redirect_target

--- a/tests/follows/test_follow_api.py
+++ b/tests/follows/test_follow_api.py
@@ -1,5 +1,5 @@
 import pytest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework import status
 
 from adhocracy4.follows import models as follow_models

--- a/tests/polls/test_question_api.py
+++ b/tests/polls/test_question_api.py
@@ -1,7 +1,7 @@
 import pytest
 
 from rest_framework import status
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from adhocracy4.polls.models import Question
 
 

--- a/tests/polls/test_validators.py
+++ b/tests/polls/test_validators.py
@@ -1,7 +1,7 @@
 import pytest
 
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from adhocracy4.polls.models import Poll
 from adhocracy4.polls.validators import single_vote_per_user
 from adhocracy4.polls.validators import single_item_per_module

--- a/tests/polls/test_vote_api.py
+++ b/tests/polls/test_vote_api.py
@@ -1,7 +1,7 @@
 import pytest
 
 from rest_framework import status
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from adhocracy4.polls.models import Vote
 from adhocracy4.polls.phases import VotingPhase
 from tests.helpers import active_phase

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -72,15 +72,14 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
 )
 
 ROOT_URLCONF = 'tests.project.urls'

--- a/tests/project/urls.py
+++ b/tests/project/urls.py
@@ -15,24 +15,24 @@ from adhocracy4.comments.api import CommentViewSet
 from adhocracy4.polls.routers import QuestionDefaultRouter
 
 router = routers.DefaultRouter()
-router.register(r'follows', FollowViewSet, base_name='follows')
-router.register(r'reports', ReportViewSet, base_name='reports')
-router.register(r'polls', PollViewSet, base_name='polls')
+router.register(r'follows', FollowViewSet, basename='follows')
+router.register(r'reports', ReportViewSet, basename='reports')
+router.register(r'polls', PollViewSet, basename='polls')
 
 question_router = QuestionDefaultRouter()
-question_router.register(r'vote', VoteViewSet, base_name='votes')
+question_router.register(r'vote', VoteViewSet, basename='votes')
 
 ct_router = a4routers.ContentTypeDefaultRouter()
-ct_router.register(r'comments', CommentViewSet, base_name='comments')
-ct_router.register(r'ratings', RatingViewSet, base_name='ratings')
+ct_router.register(r'comments', CommentViewSet, basename='comments')
+ct_router.register(r'ratings', RatingViewSet, basename='ratings')
 
 urlpatterns = [
     url(r'^api/', include(ct_router.urls)),
     url(r'^api/', include(router.urls)),
     url(r'^api/', include(question_router.urls)),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^projects/', include(prj_urls)),
     url(r'^modules/', include(mod_urls)),
-    url(r'^accounts/login', views.login, name='account_login'),
+    url(r'^accounts/login', views.LoginView, name='account_login'),
     url(r'^dashboard/', include(dashboard_urls))
 ]

--- a/tests/projects/test_project_models.py
+++ b/tests/projects/test_project_models.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import pytest
 from dateutil.parser import parse
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from freezegun import freeze_time
 

--- a/tests/projects/test_project_views.py
+++ b/tests/projects/test_project_views.py
@@ -1,5 +1,5 @@
 import pytest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from adhocracy4.test.helpers import redirect_target
 

--- a/tests/ratings/test_rating_api.py
+++ b/tests/ratings/test_rating_api.py
@@ -1,6 +1,6 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework import status
 
 from tests.apps.questions.models import Question

--- a/tests/reports/test_report_api.py
+++ b/tests/reports/test_report_api.py
@@ -1,7 +1,7 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework import status
 
 


### PR DESCRIPTION
 - update django and other packages
 - some trivial changes to make that work
 - remove 'limit_choices_to' from models. This requires an architectural change to our setup and needs to get replaced with some new solution. On the other hand it's not clear to me if the previous solution even worked (https://code.djangoproject.com/ticket/24195)

Note: AE currently uses a previous version of this PR which included migrations (now it doesn't). We need to fix that in the ae databases.