### PR TITLE
remove the topics and location from the projects django admin

### DIFF
--- a/adhocracy4/projects/admin.py
+++ b/adhocracy4/projects/admin.py
@@ -62,10 +62,6 @@ class ProjectAdmin(admin.ModelAdmin):
             'fields': ('contact_name', 'contact_address_text',
                        'contact_phone', 'contact_email', 'contact_url'),
         }),
-        (_('Topic and location'), {
-            'classes': ('collapse',),
-            'fields': ('topics', 'point', 'administrative_district'),
-        }),
     )
 
 


### PR DESCRIPTION
The topics field was breaking the projects without topics. As the only place (mB) where topic and location are actually used overwrites the project-admin anyway, we removed it here.