### PR TITLE
fill last discussed with newer of last discussed and created

### DIFF
--- a/adhocracy4/comments/signals.py
+++ b/adhocracy4/comments/signals.py
@@ -11,8 +11,9 @@ generics.setup_delete_signals(settings.A4_COMMENTABLES, Comment)
 @receiver(post_save, sender=Comment)
 def update_last_discussed(sender, instance, **kwargs):
     if hasattr(instance.content_object, 'last_discussed'):
-        if instance.modified:
-            instance.content_object.last_discussed = instance.modified
-        else:
-            instance.content_object.last_discussed = instance.created
+        last_discussed = instance.created
+        if (instance.last_discussed
+                and instance.last_discussed > last_discussed):
+            last_discussed = instance.last_discussed
+        instance.content_object.last_discussed = last_discussed
         instance.content_object.save(ignore_modified=True)


### PR DESCRIPTION
With the field modified not being modified anymore, when a comment or idea is saved in this signal, this didn't work anymore for ideas, where the last discussion was an added child-comment.