### PR TITLE
projects/end_date: exclude phases without dates to calculate end_date…

### DIFF
--- a/adhocracy4/projects/models.py
+++ b/adhocracy4/projects/models.py
@@ -400,7 +400,8 @@ class Project(ProjectContactDetailMixin,
 
     @cached_property
     def end_date(self):
-        last_phase = self.phases.order_by('end_date').last()
+        last_phase = self.phases.exclude(end_date=None)\
+            .order_by('end_date').last()
         end_date = last_phase.end_date
         if self.events:
             last_event = self.events.order_by('date').last()


### PR DESCRIPTION
… of project

SGLlite seems to put None-dates first while postgres puts them last.