### PR TITLE
modules: Fix get_timeline_index function

### DIFF
--- a/adhocracy4/modules/models.py
+++ b/adhocracy4/modules/models.py
@@ -284,8 +284,8 @@ class Module(models.Model):
     @cached_property
     def get_timeline_index(self):
         if self.project.display_timeline:
-            for count, cluster in enumerate(self.project.module_clusters):
-                if self in cluster:
+            for count, cluster in enumerate(self.project.participation_dates):
+                if 'modules' in cluster and self in cluster['modules']:
                     return count
         return 0
 


### PR DESCRIPTION
I think we have to use participation_dates as their might be events, right?