### PR TITLE
actions: Refine system actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ lint-quick:
 
 .PHONY: test
 test:
-	$(VIRTUAL_ENV)/bin/pytest
+	$(VIRTUAL_ENV)/bin/pytest --reuse-db

--- a/adhocracy4/actions/management/commands/create_system_actions.py
+++ b/adhocracy4/actions/management/commands/create_system_actions.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.contrib.contenttypes.models import ContentType
 
@@ -11,14 +12,60 @@ from adhocracy4.projects.models import Project
 class Command(BaseCommand):
     help = 'Create system actions.'
 
-    def handle(self, *args, **options):
-        self._phase_end_tomorrow()
-        self._project_start_last_hour()
+    def __init__(self):
+        if hasattr(settings, 'A4_ACTIONS_PHASE_STARTED_HOURS'):
+            self.phase_started_hours = settings.A4_ACTIONS_PHASE_STARTED_HOURS
+        else:
+            self.phase_started_hours = 1
 
-    def _phase_end_tomorrow(self):
+        if hasattr(settings, 'A4_ACTIONS_PHASE_ENDS_HOURS'):
+            self.phase_ends_hours = settings.A4_ACTIONS_PHASE_ENDS_HOURS
+        else:
+            self.phase_ends_hours = 24
+
+        if hasattr(settings, 'A4_ACTIONS_PROJECT_STARTED_HOURS'):
+            self.project_started_hours = \
+                settings.A4_ACTIONS_PROJECTED_START_HOURS
+        else:
+            self.project_started_hours = 1
+
+    def handle(self, *args, **options):
+        self._phase_started()
+        self._phase_ends()
+        self._project_started()
+
+    def _phase_started(self):
         phase_ct = ContentType.objects.get_for_model(Phase)
 
-        phases = Phase.objects.finish_next(hours=24)
+        phases = Phase.objects.start_last(hours=self.phase_started_hours)
+        for phase in phases:
+            project = phase.module.project
+            existing_action = Action.objects.filter(
+                project=project,
+                verb=Verbs.START.value,
+                obj_content_type=phase_ct,
+                obj_object_id=phase.id
+            ).first()
+
+            if not existing_action:
+                Action.objects.create(
+                    project=project,
+                    verb=Verbs.START.value,
+                    obj=phase,
+                    timestamp=phase.start_date
+                )
+
+            elif existing_action.timestamp < phase.start_date:
+                # If the first phases start has been modified and moved
+                # ahead, the existing actions timestamp has be adapted to
+                # the actual project start.
+                existing_action.timestamp = phase.start_date
+                existing_action.save()
+
+    def _phase_ends(self):
+        phase_ct = ContentType.objects.get_for_model(Phase)
+
+        phases = Phase.objects.finish_next(hours=self.phase_ends_hours)
         for phase in phases:
             project = phase.module.project
             existing_action = Action.objects.filter(
@@ -31,8 +78,8 @@ class Command(BaseCommand):
             # If the phases end has been modified and moved more than 24 hours
             # ahead, a new phase schedule action is created
             if not existing_action \
-                or (existing_action.timestamp + timedelta(hours=24)) \
-                    < phase.end_date:
+                or (existing_action.timestamp +
+                    timedelta(hours=self.phase_ends_hours)) < phase.end_date:
 
                 Action.objects.create(
                     project=project,
@@ -40,10 +87,10 @@ class Command(BaseCommand):
                     obj=phase,
                 )
 
-    def _project_start_last_hour(self):
+    def _project_started(self):
         project_ct = ContentType.objects.get_for_model(Project)
 
-        phases = Phase.objects.start_last(hours=1)
+        phases = Phase.objects.start_last(hours=self.project_started_hours)
         for phase in phases:
             if phase.is_first_of_project():
                 project = phase.module.project


### PR DESCRIPTION
* rename _phase_end_tomorrow -> _phase_ends
* rename _project_start_last_hour -> _project_started
* read number of hours from config if available
* add '_phase_started' - like _project_started, for multimodules

and some more, see commits