### PR TITLE
tests/polls: Compare user_choices_list to a choice, not a vote

### DIFF
--- a/tests/polls/test_models.py
+++ b/tests/polls/test_models.py
@@ -21,10 +21,10 @@ def test_question_choice_list(user,
 
     assert question.user_choices_list(anonym) == []
 
-    vote = vote_factory(creator=user, choice=choice1)
+    vote_factory(creator=user, choice=choice1)
 
     assert len(question.user_choices_list(user)) == 1
-    assert question.user_choices_list(user)[0] == vote.id
+    assert question.user_choices_list(user)[0] == choice1.id
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This was previously not detected as we run our tests on travis without
`--reuse-db`. With a fresh database, this test would coincidentally
compare two ids with the value `1`, but from different tables.

Propperly compare choice to choice instead.