### PR TITLE
translations: mark context of word comment

### DIFF
--- a/adhocracy4/comments/models.py
+++ b/adhocracy4/comments/models.py
@@ -4,6 +4,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
+from django.utils.translation import pgettext
 from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4 import transforms
@@ -49,7 +50,7 @@ class Comment(base.UserGeneratedContentModel):
     )
 
     class Meta:
-        verbose_name = _("Comment")
+        verbose_name = pgettext("noun", "Comment")
         verbose_name_plural = _("Comments")
         ordering = ('created',)
         index_together = [('content_type', 'object_pk')]

--- a/adhocracy4/comments_async/static/comments_with_categories/comment.jsx
+++ b/adhocracy4/comments_async/static/comments_with_categories/comment.jsx
@@ -34,7 +34,7 @@ const getAnswerForm = function (hide) {
   if (hide) {
     fmts = django.gettext('hide comments')
   } else {
-    fmts = django.gettext('Comment')
+    fmts = django.pgettext('verb', 'Comment')
   }
   return (fmts)
 }


### PR DESCRIPTION
This will solve (the a4-part) of https://github.com/liqd/adhocracy-plus/issues/285
But it will break some translations for the other projects when updating, so we need to redo them then.