### PR TITLE
apps/comments async: make sure the category choices are a dict when j…

### DIFF
--- a/adhocracy4/comments_async/templatetags/react_comments_async.py
+++ b/adhocracy4/comments_async/templatetags/react_comments_async.py
@@ -40,8 +40,10 @@ def react_comments_async(context, obj, with_categories=False):
 
     with_categories = bool(with_categories)
 
-    comment_category_choices = getattr(settings, 'A4_COMMENT_CATEGORIES', None)
+    comment_category_choices = {}
     if with_categories:
+        comment_category_choices = getattr(settings,
+                                           'A4_COMMENT_CATEGORIES', None)
         if comment_category_choices:
             comment_category_choices = dict(
                 (x, str(y)) for x, y in comment_category_choices)


### PR DESCRIPTION
…son serialized

This broke the tests in a+, because if there are categories in the settings, for the comments without categories, the categories were still given to the json serializer, but as a tuple, which it couldn't handle. :roll_eyes: Now the categories are only given to the comments if they are needed (for comments with categories). The comments without categories get and empty dict, which the serializer can handle.