### PR TITLE
assets: Replace jQuery 'a4.embed.ready' listeners with vanilla js

### DIFF
--- a/adhocracy4/categories/assets/category_formset.js
+++ b/adhocracy4/categories/assets/category_formset.js
@@ -1,7 +1,7 @@
 /* global $ */
 (function (init) {
-  $(init)
-  $(document).on('a4.embed.ready', init)
+  document.addEventListener('DOMContentLoaded', init, false)
+  document.addEventListener('a4.embed.ready', init, false)
 })(function () {
   // Dynamically add or remove subforms to a formset.
 

--- a/adhocracy4/categories/assets/select_dropdown_init.js
+++ b/adhocracy4/categories/assets/select_dropdown_init.js
@@ -1,7 +1,7 @@
 /* global $ */
 (function (init) {
-  $(init)
-  $(document).on('a4.embed.ready', init)
+  document.addEventListener('DOMContentLoaded', init, false)
+  document.addEventListener('a4.embed.ready', init, false)
 })(function () {
   if ($.fn.selectdropdown) {
     $('.select-dropdown').selectdropdown()

--- a/adhocracy4/images/assets/image_uploader.js
+++ b/adhocracy4/images/assets/image_uploader.js
@@ -1,5 +1,5 @@
 /* global $ */
-var init = function () {
+function init () {
   var clearInputs = $('input[data-upload-clear]')
   var previewImages = $('img[data-upload-preview]')
 
@@ -28,5 +28,5 @@ var init = function () {
   })
 }
 
-$(init)
-$(document).on('a4.embed.ready', init)
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)

--- a/adhocracy4/maps/static/a4maps/a4maps_choose_point.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_choose_point.js
@@ -78,7 +78,7 @@ function isMarkerInsidePolygon (marker, poly) {
   return inside
 }
 
-var init = function () {
+function init () {
   var $ = window.jQuery
   var L = window.L
 
@@ -148,5 +148,5 @@ var init = function () {
   })
 }
 
-window.jQuery(init)
-window.jQuery(document).on('a4.embed.ready', init)
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)

--- a/adhocracy4/maps/static/a4maps/a4maps_choose_polygon.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_choose_polygon.js
@@ -12,7 +12,7 @@ function getBaseBounds (L, polygon, bbox) {
   }
 }
 
-var init = function () {
+function init () {
   var $ = window.jQuery
   var L = window.L
 
@@ -105,5 +105,5 @@ var init = function () {
   })
 }
 
-window.jQuery(init)
-window.jQuery(document).on('a4.embed.ready', init)
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)

--- a/adhocracy4/maps/static/a4maps/a4maps_display_point.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_display_point.js
@@ -1,6 +1,6 @@
 import { createMap } from './a4maps_common'
 
-var init = function () {
+function init () {
   var $ = window.jQuery
   var L = window.L
 
@@ -64,5 +64,5 @@ var init = function () {
   })
 }
 
-window.jQuery(init)
-window.jQuery(document).on('a4.embed.ready', init)
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)

--- a/adhocracy4/maps/static/a4maps/a4maps_display_points.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_display_points.js
@@ -1,7 +1,7 @@
 import { createMap } from './a4maps_common'
 import 'leaflet.markercluster'
 
-var init = function () {
+function init () {
   var $ = window.jQuery
   var L = window.L
 
@@ -150,5 +150,5 @@ var init = function () {
   })
 }
 
-window.jQuery(init)
-window.jQuery(document).on('a4.embed.ready', init)
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)

--- a/adhocracy4/static/api.js
+++ b/adhocracy4/static/api.js
@@ -1,14 +1,14 @@
 var $ = require('jquery')
 var cookie = require('js-cookie')
 
-var init = function () {
+function init () {
   $.ajaxSetup({
     headers: { 'X-CSRFToken': cookie.get('csrftoken') }
   })
 }
 
-$(init)
-$(document).on('a4.embed.ready', init)
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)
 
 var baseURL = '/api/'
 


### PR DESCRIPTION
When using multple webpack endpoints we do not get a global jQuery
object but instead one for each endpoint. These do not see each others
signals, thus do not fire.

Use standard js events instead - they don't suffer from that problem and
we should get rid of jQuery anyway over time.

Also use the chance to clean up the init syntax.