### PR TITLE
apps/maps: show no of comments even when no rating is shown

### DIFF
--- a/adhocracy4/maps/static/a4maps/a4maps_display_points.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_display_points.js
@@ -91,7 +91,11 @@ function init () {
             '</span>' +
         '</div>'
       } else if (hideRatings === 'true') {
-        return ''
+        return '<div class="maps-popups-popup-meta">' +
+            '<span class="map-popup-comments-count">' +
+            feature.properties.comments_count + ' <i class="far fa-comment" aria-hidden="true"></i>' +
+            '</span>' +
+        '</div>'
       }
     }
 


### PR DESCRIPTION
This was actually already working! This is a small change and then it will fix https://github.com/liqd/a4-meinberlin/issues/1932 to everyones happiness!