### PR TITLE
dependencies: jquery downgrade to 3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "immutability-helper": "3.0.2",
-    "jquery": "3.5.0",
+    "jquery": "^3.4.1",
     "js-cookie": "2.2.1",
     "leaflet": "1.6.0",
     "leaflet-draw": "1.0.4",


### PR DESCRIPTION
I made a pull request as don't want it to auto merge again and I thought ^ will stop that? 