### PR TITLE
renovate: Use the same settings as other projects

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,27 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+
+  "dependencies": {
+    "updateTypes": ["patch"],
+    "automerge": true
+  },
+  "devDependencies": {
+    "updateTypes": ["minor", "patch"],
+    "automerge": true
+  },
+
+  "labels": [
+    "renovate"
+  ],
+
+  "packageRules": [
+      {
+        "packagePatterns": ["^eslint"],
+        "groupName": "eslint packages"
+      }
+    ],
+
+  "schedule": ["on tuesday"]
 }


### PR DESCRIPTION
Most importantly automerge patch updates, i.e. 1.0.x for "runtime" dependencies (it's
actually only used during build) and also minor updates, i.e. 1.x.x for
dev dependencies.