### PR TITLE
assets: Register jQuery plugins to window.jQuery

### DIFF
--- a/adhocracy4/categories/assets/category_formset.js
+++ b/adhocracy4/categories/assets/category_formset.js
@@ -1,10 +1,9 @@
-/* global $ */
 (function (init) {
   document.addEventListener('DOMContentLoaded', init, false)
   document.addEventListener('a4.embed.ready', init, false)
 })(function () {
   // Dynamically add or remove subforms to a formset.
-
+  const $ = window.jQuery
   var $formsets = $('.js-formset')
   var PLACEHOLDER = /__prefix__/g
   var dynamicFormSets = []

--- a/adhocracy4/categories/assets/select_dropdown_init.js
+++ b/adhocracy4/categories/assets/select_dropdown_init.js
@@ -1,8 +1,8 @@
-/* global $ */
 (function (init) {
   document.addEventListener('DOMContentLoaded', init, false)
   document.addEventListener('a4.embed.ready', init, false)
 })(function () {
+  const $ = window.jQuery
   if ($.fn.selectdropdown) {
     $('.select-dropdown').selectdropdown()
   }

--- a/adhocracy4/static/select_dropdown.js
+++ b/adhocracy4/static/select_dropdown.js
@@ -1,4 +1,3 @@
-/* global jQuery */
 /*
 This adds a jQuery plugin called `selectdropdown` which transforms a html <select> into a bootstrap dropdown.
 The idea is borrowed from https://github.com/silviomoreto/bootstrap-select which provides a lot more functionality
@@ -131,4 +130,4 @@ The following classes are available:
       }
     })
   }
-}(jQuery))
+}(window.jQuery))


### PR DESCRIPTION
The global $ is now usually provided by Webpack - unfortunately that
does not play well with registering jQuery plugins, as the global
jQuery object is not shared between endpoints (or read-only?).

Closes https://github.com/liqd/a4-meinberlin/issues/2935