### PR TITLE
exports/mixins: make export of html fields work if there is more than…

### DIFF
--- a/adhocracy4/exports/mixins.py
+++ b/adhocracy4/exports/mixins.py
@@ -54,7 +54,8 @@ class ExportModelFieldsMixin(VirtualFieldMixin):
         for field in html_fields:
             get_field_attr_name = 'get_%s_data' % field
             setattr(self, get_field_attr_name,
-                    lambda item: unescape_and_strip_html(getattr(item, field)))
+                    lambda item, field_name=field:
+                    unescape_and_strip_html(getattr(item, field_name)))
 
 
 class ItemExportWithRatesMixin(VirtualFieldMixin):


### PR DESCRIPTION
… one of them

Problem was that each of the lambda functions were binded to the same variable 'field' that takes a different value in each loop. Thus at the end of the for loop, all of the lambda functions were binded to the last taken value of field, i.e. all lambda functions returned the data of the last field in the html_field list. Well described [here](https://stackoverflow.com/questions/33134609/python-setattr-for-dynamic-method-creator-with-decorator).  