### PR TITLE
apps/export: export empty string if value is none

### DIFF
--- a/adhocracy4/exports/views.py
+++ b/adhocracy4/exports/views.py
@@ -86,6 +86,8 @@ class BaseExport(VirtualFieldMixin):
         value = getattr(item, name, '')
         if isinstance(value, numbers.Number) and not isinstance(value, bool):
             return value
+        elif value is None:
+            return ''
         return str(value)
 
 


### PR DESCRIPTION
fixes that none values are exported as string "None" like on https://meinberlin-dev.liqd.net/dashboard/organisations/liqd/plans/