### PR TITLE
index: Add common map functions to exports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,13 @@
 {
-  "extends": ["standard", "standard-jsx"],
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true,
+    "jquery": true
+  },
+  "extends": [
+    "standard",
+    "standard-jsx"],
   "rules": {
     "jsx-quotes": [2, "prefer-double"]
   }

--- a/adhocracy4/maps/static/a4maps/a4maps_choose_point.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_choose_point.js
@@ -79,7 +79,6 @@ function isMarkerInsidePolygon (marker, poly) {
 }
 
 function init () {
-  var $ = window.jQuery
   var L = window.L
 
   $('[data-map="choose_point"]').each(function (i, e) {

--- a/adhocracy4/maps/static/a4maps/a4maps_choose_polygon.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_choose_polygon.js
@@ -13,7 +13,6 @@ function getBaseBounds (L, polygon, bbox) {
 }
 
 function init () {
-  var $ = window.jQuery
   var L = window.L
 
   $('[data-map="choose_polygon"]').each(function (i, e) {

--- a/adhocracy4/maps/static/a4maps/a4maps_display_point.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_display_point.js
@@ -1,7 +1,6 @@
 import { createMap } from './a4maps_common'
 
 function init () {
-  var $ = window.jQuery
   var L = window.L
 
   $('[data-map="display_point"]').each(function (i, e) {

--- a/adhocracy4/maps/static/a4maps/a4maps_display_points.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_display_points.js
@@ -2,7 +2,6 @@ import { createMap } from './a4maps_common'
 import 'leaflet.markercluster'
 
 function init () {
-  var $ = window.jQuery
   var L = window.L
 
   var escapeHtml = function (unsafe) {

--- a/adhocracy4/static/global_jquery.jsx
+++ b/adhocracy4/static/global_jquery.jsx
@@ -1,0 +1,1 @@
+window.jQuery = window.$ = require('jquery')

--- a/adhocracy4/static/widget.js
+++ b/adhocracy4/static/widget.js
@@ -1,22 +1,16 @@
-var $ = window.jQuery = window.$ = require('jquery')
-
 /* Intializes adhcoracy4 react widgets without inline code
  *
  * The element `<div data-$namespace-$name></div>` triggers and invocation of
  * $fn with the div dom node as argument. Further arguments should be passed as
  * additional data attributes. The widget is expected to render inside the div.
  */
-var initialise = function (namespace, name, fn) {
-  var key = 'data-' + namespace + '-widget'
-  var selector = '[' + key + '=' + name + ']'
+export function initialise (namespace, name, fn) {
+  const key = 'data-' + namespace + '-widget'
+  const selector = '[' + key + '=' + name + ']'
   $(selector).each(function (i, el) {
     fn(el)
 
     // avoid double-initialisation
     el.removeAttribute(key)
   })
-}
-
-module.exports = {
-  initialise: initialise
 }

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ export { default as comments } from './adhocracy4/comments/static/comments/react
 export { default as commentsAsync } from './adhocracy4/comments_async/static/comments_async/index'
 export { default as config } from './adhocracy4/static/config'
 export { default as follows } from './adhocracy4/follows/static/follows/react_follows'
+export * as maps from './adhocracy4/maps/static/a4maps/a4maps_common'
 export { default as polls } from './adhocracy4/polls/static/polls/react_polls'
 export { default as ratings } from './adhocracy4/ratings/static/ratings/react_ratings'
 export { default as reports } from './adhocracy4/reports/static/reports/react_reports'

--- a/index.js
+++ b/index.js
@@ -1,13 +1,16 @@
-module.exports = {
-  ratings: require('./adhocracy4/ratings/static/ratings/react_ratings.jsx'),
-  comments: require('./adhocracy4/comments/static/comments/react_comments.jsx'),
-  comments_async: require('./adhocracy4/comments_async/static/comments_async/index.jsx'),
-  reports: require('./adhocracy4/reports/static/reports/react_reports.jsx'),
-  follows: require('./adhocracy4/follows/static/follows/react_follows.jsx'),
-  polls: require('./adhocracy4/polls/static/polls/react_polls.jsx'),
-  config: require('./adhocracy4/static/config.js'),
-  api: require('./adhocracy4/static/api.js'),
-  widget: require('./adhocracy4/static/widget.js'),
-  selectDropdown: require('./adhocracy4/static/select_dropdown.js'),
-  alert: require('./adhocracy4/static/Alert.jsx')
-}
+/* This is a workaround for a certain ES5 related import mess.
+ * It should not be needed any more once we switch to full ES6.
+ */
+import './adhocracy4/static/global_jquery'
+
+export { default as alert } from './adhocracy4/static/Alert'
+export { default as api } from './adhocracy4/static/api'
+export { default as comments } from './adhocracy4/comments/static/comments/react_comments'
+export { default as commentsAsync } from './adhocracy4/comments_async/static/comments_async/index'
+export { default as config } from './adhocracy4/static/config'
+export { default as follows } from './adhocracy4/follows/static/follows/react_follows'
+export { default as polls } from './adhocracy4/polls/static/polls/react_polls'
+export { default as ratings } from './adhocracy4/ratings/static/ratings/react_ratings'
+export { default as reports } from './adhocracy4/reports/static/reports/react_reports'
+export { default as selectDropdown } from './adhocracy4/static/select_dropdown'
+export * as widget from './adhocracy4/static/widget'


### PR DESCRIPTION
This way we can finally remove the alias magic in webpack from
our frontends.

Also some more cleanups and ES6 ports.