### PR TITLE
maps/assets: Add leaflet attribution layer to vector maps

### DIFF
--- a/adhocracy4/maps/static/a4maps/a4maps_common.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_common.js
@@ -47,6 +47,8 @@ export function createMap (L, e, {
         }).addTo(map)
       }
     }
+    const attributionLayer = L.tileLayer('', { attribution: attribution })
+    attributionLayer.addTo(map)
   } else {
     let basemap = baseUrl + '{z}/{x}/{y}.png'
     let accessToken = ''

--- a/adhocracy4/maps/static/a4maps/a4maps_common.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_common.js
@@ -30,7 +30,6 @@ export function createMap (L, e, {
     } else {
       if (omtToken !== '') {
         L.mapboxGL({
-          accessToken: 'no-token',
           style: baseUrl,
           transformRequest: function (url, resourceType) {
             if (resourceType === 'Tile' && url.indexOf('https://') === 0) {
@@ -42,7 +41,6 @@ export function createMap (L, e, {
         }).addTo(map)
       } else {
         L.mapboxGL({
-          accessToken: 'no-token',
           style: baseUrl
         }).addTo(map)
       }


### PR DESCRIPTION
Properly include the passed in attribution - this was overlooked
during the initial implementation.