### PR TITLE
apps/projects and modules: add time_left property for < 1 second

### DIFF
--- a/adhocracy4/modules/models.py
+++ b/adhocracy4/modules/models.py
@@ -195,6 +195,7 @@ class Module(models.Model):
                     else:
                         unit_totals.append((unit_name[0], amount))
                     seconds = seconds - (amount * limit)
+            unit_totals.append((_('seconds'), 0))
 
             return unit_totals
 

--- a/adhocracy4/projects/models.py
+++ b/adhocracy4/projects/models.py
@@ -595,6 +595,7 @@ class Project(ProjectContactDetailMixin,
                     else:
                         unit_totals.append((unit_name[0], amount))
                     seconds = seconds - (amount * limit)
+            unit_totals.append((_('seconds'), 0))
 
             return unit_totals
 

--- a/tests/modules/test_module_models.py
+++ b/tests/modules/test_module_models.py
@@ -189,6 +189,11 @@ def test_module_running_time_left(phase_factory):
         start_date=parse('2013-01-01 19:00:01 UTC'),
         end_date=parse('2013-01-01 20:00:00 UTC')
     )
+    phase5 = phase_factory(
+        start_date=parse('2013-01-01 17:00:00 UTC'),
+        end_date=parse('2013-01-01 18:00:00.45 UTC')
+    )
+    module4 = phase5.module
     with freeze_time('2013-01-01 18:00:00 UTC'):
         assert module1.module_running_time_left \
             == '1 day'
@@ -196,6 +201,8 @@ def test_module_running_time_left(phase_factory):
             == '1 second'
         assert module3.module_running_time_left \
             == '2 hours'
+        assert module4.module_running_time_left \
+            == '0 seconds'
 
 
 @pytest.mark.django_db

--- a/tests/projects/test_project_model_module_properties.py
+++ b/tests/projects/test_project_model_module_properties.py
@@ -168,7 +168,9 @@ def test_module_running_days_left(project, module_factory, phase_factory):
 
 
 @pytest.mark.django_db
-def test_module_running_time_left(project, module_factory, phase_factory):
+def test_module_running_time_left(project_factory, module_factory,
+                                  phase_factory):
+    project = project_factory()
     module1 = module_factory(project=project, weight=1)
     phase_factory(
         module=module1,
@@ -180,8 +182,16 @@ def test_module_running_time_left(project, module_factory, phase_factory):
         start_date=parse('2013-01-01 19:00:00 UTC'),
         end_date=parse('2013-01-02 19:05:00 UTC')
     )
+    project2 = project_factory()
+    module2 = module_factory(project=project2, weight=1)
+    phase_factory(
+        module=module2,
+        start_date=parse('2013-01-01 18:00:00 UTC'),
+        end_date=parse('2013-01-01 18:30:00.45 UTC')
+    )
     with freeze_time('2013-01-01 18:30:00 UTC'):
         assert project.module_running_time_left == '1 day'
+        assert project2.module_running_time_left == '0 seconds'
 
 
 @pytest.mark.django_db

--- a/tests/projects/test_project_model_phase_properties.py
+++ b/tests/projects/test_project_model_phase_properties.py
@@ -318,6 +318,18 @@ def test_time_left_seconds(project, module_factory, phase_factory):
 
 
 @pytest.mark.django_db
+def test_time_left_0_seconds(project, module_factory, phase_factory):
+    module1 = module_factory(project=project, weight=1)
+    phase_factory(
+        module=module1,
+        start_date=parse('2013-01-01 16:00:00 UTC'),
+        end_date=parse('2013-01-01 18:00:00.45 UTC')
+    )
+    with freeze_time('2013-01-01 18:00:00 UTC'):
+        assert project.time_left == '0 seconds'
+
+
+@pytest.mark.django_db
 def test_active_phase_progress(project, module_factory, phase_factory):
     module1 = module_factory(project=project, weight=1)
     module2 = module_factory(project=project, weight=2)


### PR DESCRIPTION
fixes https://sentry.liqd.net/organizations/sentry/issues/1293
I didn't know how to get that error manually, so added the tests to do that.