### PR TITLE
static: Avoid reinitializing window.jQuery

### DIFF
--- a/adhocracy4/static/global_jquery.jsx
+++ b/adhocracy4/static/global_jquery.jsx
@@ -1,1 +1,3 @@
-window.jQuery = window.$ = require('jquery')
+if (window.jQuery === undefined) {
+  window.jQuery = window.$ = require('jquery')
+}


### PR DESCRIPTION
This code runs unconditionally when importing anything from adhocracy4
via node/ES5 `require`. Depending on order, this would make us
overwrite an existing `window.jQuery` instance - which may have been
extented by e.g. `select2`, which then broke.