### PR TITLE
apps/comments: only show comment form for answering when commenting p…

### DIFF
--- a/adhocracy4/comments/static/comments/Comment.jsx
+++ b/adhocracy4/comments/static/comments/Comment.jsx
@@ -212,9 +212,9 @@ class Comment extends React.Component {
             </div>
           </div>}
 
-        {this.state.showChildComments
-          ? (
-            <div className="comment-child-list">
+        <div className="comment-child-list">
+          {this.state.showChildComments
+            ? (
               <CommentList
                 comments={this.props.child_comments}
                 parentIndex={this.props.index}
@@ -222,7 +222,10 @@ class Comment extends React.Component {
                 onCommentModify={this.props.onCommentModify}
                 isReadOnly={this.props.isReadOnly}
                 onEditErrorClick={this.props.onEditErrorClick}
-              />
+              />) : null}
+
+          {this.state.showChildComments && !this.props.isReadOnly
+            ? (
               <CommentForm
                 subjectType={this.context.comments_contenttype}
                 subjectId={this.props.id}
@@ -234,8 +237,8 @@ class Comment extends React.Component {
                 handleErrorClick={() => this.props.handleReplyErrorClick(this.props.index, this.props.parentIndex)}
                 rows="3"
                 grabFocus={this.state.replyFormHasFocus}
-              />
-            </div>) : null}
+              />) : null}
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
…ossible

Will fix https://github.com/liqd/a4-meinberlin/issues/3421

It would have been quite easy displaying the same text by adding the isReadOnly and isContextMember to the CommentForm also for child comments. But that didn't make lot of sense, so this only displays the comment form (or the appropriate text), when the phase allows commenting (or you're logged in as admin or initiator and so on (see isReadOnly)). Tonight my brain is not working well enough anymore to also understand what is and should be happening for semi-public projects. So, we still need to check that. And it will probably also have to be fixed on the async comments.
So, to do:

- [x] check semi-public projects
- [ ] check and (most likely) fix for async comments