### PR TITLE
settings: make isort not check migrations even when passed as argument

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,5 +17,6 @@ indent_style = tab
 # isort configuration
 [*.py]
 skip=migrations,node_modules,venv
+skip_glob = */migrations/*.py
 known_first_party=adhocracy4, tests
 force_single_line = true

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ lint-quick:
 .PHONY: lint-python-files
 lint-python-files:
 	EXIT_STATUS=0; \
-	$(VIRTUAL_ENV)/bin/isort --df -c $(ARGUMENTS) || EXIT_STATUS=$$?; \
+	$(VIRTUAL_ENV)/bin/isort --diff -c $(ARGUMENTS) --filter-files || EXIT_STATUS=$$?; \
 	$(VIRTUAL_ENV)/bin/flake8 $(ARGUMENTS) || EXIT_STATUS=$$?; \
 	exit $${EXIT_STATUS}
 


### PR DESCRIPTION
With this, isort doesn't check the migrations, but flake8 still does, I couldn't fix that. :(