### PR TITLE
apps/questions: fixing poll buttons

### DIFF
--- a/adhocracy4/polls/static/polls/Question.jsx
+++ b/adhocracy4/polls/static/polls/Question.jsx
@@ -135,17 +135,21 @@ class Question extends React.Component {
   }
 
   toggleShowResultButton () {
-    let toggleShowResultButtonText
-    if (this.state.showResult) {
-      toggleShowResultButtonText = django.gettext('To poll')
-      if (this.state.selectedChoices.length !== 0) {
-        toggleShowResultButtonText = django.gettext('Change vote')
-      }
-    } else {
-      toggleShowResultButtonText = django.gettext('Show preliminary results')
-    }
+    const { showResult, selectedChoices: { length: isVoted } } = this.state
+    const buttonText = !showResult
+      ? django.gettext('Show preliminary results')
+      : isVoted
+        ? django.gettext('Change vote')
+        : django.gettext('To poll')
+
     return (
-      toggleShowResultButtonText
+      <button
+        type="button"
+        className="btn btn--link"
+        onClick={this.toggleShowResult.bind(this)}
+      >
+        {buttonText}
+      </button>
     )
   }
 


### PR DESCRIPTION
In Question.jsx a bug around 'showing preliminary results' button is fixed
Additionally following bugs to go back 'to poll' and 'change vote' buttons
are also fixed.

Fixes #2106 (a4-opin repo though)