### PR TITLE
WIP: apps/dashboard: add widget enum overwrite

### DIFF
--- a/adhocracy4/dashboard/apps.py
+++ b/adhocracy4/dashboard/apps.py
@@ -9,3 +9,6 @@ class Config(AppConfig):
         from django.utils.module_loading import autodiscover_modules
         autodiscover_modules('dashboard', register_to=self.module.components)
         self.module.components.apply_replacements()
+
+        from . import overwrites
+        overwrites.overwrite_access_enum_label()

--- a/adhocracy4/dashboard/forms.py
+++ b/adhocracy4/dashboard/forms.py
@@ -71,11 +71,20 @@ class ProjectBasicForm(ProjectDashboardForm):
         required_for_project_publish = ['name', 'description']
         widgets = {
             'access': RadioSelect(
+                # FIXME: these choices are currently ignored by djangos widget
+                # machinery - we work around that in
+                # adhocracy4/dashbord/overwrites
                 choices=[
                     (Access.PUBLIC,
-                     _('All users can participate (public).')),
+                     _('All users can see project tile and content and can '
+                       'participate (public).')),
                     (Access.PRIVATE,
-                     _('Only invited users can participate (private).'))
+                     _('Only invited users can see project tile and '
+                       'content and can participate (private).')),
+                    (Access.SEMIPUBLIC,
+                     _('All users can see project tile and content, '
+                       'only invited users can participate '
+                       '(semi-public).'))
                 ]
             ),
         }

--- a/adhocracy4/dashboard/overwrites.py
+++ b/adhocracy4/dashboard/overwrites.py
@@ -1,0 +1,15 @@
+from django.utils.translation import ugettext_lazy as _
+
+from adhocracy4.projects.enums import Access
+
+
+def overwrite_access_enum_label():
+    Access.__labels__ = {
+        Access.PRIVATE: _('Only invited users can see project tile and '
+                          'content and can participate (private).'),
+        Access.PUBLIC: _('All users can see project tile and content and can '
+                         'participate (public).'),
+        Access.SEMIPUBLIC: _('All users can see project tile and content, '
+                             'only invited users can participate '
+                             '(semi-public).')
+    }


### PR DESCRIPTION
This are the texts and values we use in the projects as well (a+ and mB).
As overwriting the widget with less values doesn't have an effect, we can as well put all values there.