### PR TITLE
apps/dashboard: copy moderators over on project duplicate

### DIFF
--- a/adhocracy4/dashboard/mixins.py
+++ b/adhocracy4/dashboard/mixins.py
@@ -178,6 +178,9 @@ class DashboardProjectDuplicateMixin:
                                          project=project_clone,
                                          user=self.request.user)
 
+            for moderator in project.moderators.all():
+                project_clone.moderators.add(moderator)
+
             for module in project.module_set.all():
                 module_clone = deepcopy(module)
                 module_clone.project = project_clone

--- a/tests/dashboard/test_views.py
+++ b/tests/dashboard/test_views.py
@@ -246,6 +246,8 @@ def test_project_duplicate(client, another_user,
     assert project_clone.created > project.created
     for attr in ('description', 'information', 'result', 'access'):
         assert getattr(project_clone, attr) == getattr(project, attr)
+    for moderator in project.moderators.all():
+        assert moderator in project.moderators.all()
 
     module_clone = project_clone.module_set.first()
     assert module_clone.pk != module.pk


### PR DESCRIPTION
This avoids having no moderators in a project.
Fixes https://github.com/liqd/adhocracy-plus/issues/1063