### PR TITLE
polls/models: add validation before save

### DIFF
--- a/adhocracy4/polls/api.py
+++ b/adhocracy4/polls/api.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 from adhocracy4.api.permissions import ViewSetRulesPermission
 
+from .models import Answer
 from .models import Choice
 from .models import OtherVote
 from .models import Poll
@@ -34,22 +35,29 @@ class VoteViewSet(viewsets.ViewSet):
     permission_classes = (ViewSetRulesPermission,)
 
     def create(self, request, *args, **kwargs):
-        choices, other_choice_answer = self.get_data(request)
+        choices, other_choice_answer, open_answer = self.get_data(request)
 
         self.validate_choices(choices)
 
         with transaction.atomic():
-            self.clear_current_choices()
-            for choice in choices:
-                vote = Vote.objects.create(
-                    choice_id=choice.id,
+            if self.question.is_open:
+                self.clear_open_answer()
+                Answer.objects.create(
+                    question=self.question,
+                    answer=open_answer,
                     creator=self.request.user
                 )
-                if choice.is_other_choice:
-                    if choice.id == int(other_choice_answer['id']):
+            else:
+                self.clear_current_choices()
+                for choice in choices:
+                    vote = Vote.objects.create(
+                        choice_id=choice.id,
+                        creator=self.request.user
+                    )
+                    if choice.is_other_choice:
                         OtherVote.objects.create(
                             vote=vote,
-                            answer=other_choice_answer['answer']
+                            answer=other_choice_answer
                         )
 
         question_serializer = self.get_question_serializer()
@@ -66,7 +74,9 @@ class VoteViewSet(viewsets.ViewSet):
 
         other_choice_answer = request.data['other_choice_answer']
 
-        return choices, other_choice_answer
+        open_answer = request.data['open_answer']
+
+        return choices, other_choice_answer, open_answer
 
     def validate_choices(self, choices):
         question = self.question
@@ -85,6 +95,12 @@ class VoteViewSet(viewsets.ViewSet):
     def clear_current_choices(self):
         Vote.objects\
             .filter(choice__question_id=self.question.id,
+                    creator=self.request.user)\
+            .delete()
+
+    def clear_open_answer(self):
+        Answer.objects\
+            .filter(question_id=self.question.id,
                     creator=self.request.user)\
             .delete()
 

--- a/adhocracy4/polls/models.py
+++ b/adhocracy4/polls/models.py
@@ -101,9 +101,31 @@ class Question(models.Model):
         answers = self.answers.filter(creator=user)
         if answers.exists():
             # there can only be one answer bc of unique constraint
-            return answers.first().answer
+            return answers.first().id
         else:
             return ''
+
+    def other_choice_answers(self):
+        if self.has_other_option:
+            other_choice = self.choices.filter(is_other_choice=True).first()
+            other_answers = OtherVote.objects.filter(vote__choice=other_choice)
+            return other_answers
+        else:
+            return OtherVote.objects.none()
+
+    def other_choice_user_answer(self, user):
+        if not user.is_authenticated:
+            return ''
+
+        elif self.has_other_option:
+            other_choice = self.choices.filter(is_other_choice=True).first()
+            other_choice_user_answer = OtherVote.objects.filter(
+                vote__creator=user,
+                vote__choice=other_choice)
+            if other_choice_user_answer.exists():
+                # there can only be one other vote as 1:1 relation
+                return other_choice_user_answer.first().vote.id
+        return ''
 
     def get_absolute_url(self):
         return self.poll.get_absolute_url()

--- a/adhocracy4/polls/static/polls/PollManagement.jsx
+++ b/adhocracy4/polls/static/polls/PollManagement.jsx
@@ -52,7 +52,8 @@ class PollManagement extends React.Component {
       choices: [
         this.getNewChoice(),
         this.getNewChoice()
-      ]
+      ],
+      answers: []
     }
   }
 

--- a/tests/polls/conftest.py
+++ b/tests/polls/conftest.py
@@ -1,11 +1,29 @@
+import pytest
 from pytest_factoryboy import register
 
 from tests.polls import factories as poll_factories
 
 register(poll_factories.PollFactory)
 register(poll_factories.QuestionFactory)
+register(poll_factories.OpenQuestionFactory, 'open_question')
 register(poll_factories.AnswerFactory)
 register(poll_factories.ChoiceFactory)
+register(poll_factories.OtherChoiceFactory, 'other_choice')
 register(poll_factories.VoteFactory)
+register(poll_factories.VoteOnOtherChoiceFactory, 'vote_on_other')
 register(poll_factories.OtherVoteFactory)
-register(poll_factories.OpenQuestionFactory)
+
+
+@pytest.fixture
+def answer__question(open_question):
+    return open_question
+
+
+@pytest.fixture
+def other_vote__vote(vote_on_other):
+    return vote_on_other
+
+
+@pytest.fixture
+def vote_on_other__choice(other_choice):
+    return other_choice

--- a/tests/polls/factories.py
+++ b/tests/polls/factories.py
@@ -54,6 +54,16 @@ class ChoiceFactory(factory.django.DjangoModelFactory):
     question = factory.SubFactory(QuestionFactory)
 
 
+class OtherChoiceFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = models.Choice
+
+    label = factory.Faker('sentence', nb_words=4)
+    question = factory.SubFactory(QuestionFactory)
+    is_other_choice = True
+
+
 class VoteFactory(factory.django.DjangoModelFactory):
 
     class Meta:
@@ -63,10 +73,19 @@ class VoteFactory(factory.django.DjangoModelFactory):
     choice = factory.SubFactory(ChoiceFactory)
 
 
+class VoteOnOtherChoiceFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = models.Vote
+
+    creator = factory.SubFactory(UserFactory)
+    choice = factory.SubFactory(OtherChoiceFactory)
+
+
 class OtherVoteFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = models.OtherVote
 
-    vote = factory.SubFactory(VoteFactory)
+    vote = factory.SubFactory(VoteOnOtherChoiceFactory)
     answer = factory.Faker('sentence', nb_words=4)

--- a/tests/polls/test_models.py
+++ b/tests/polls/test_models.py
@@ -36,7 +36,7 @@ def test_user_answer(open_question,
     answer = answer_factory(creator=user1, answer='user answer',
                             question=open_question)
     assert open_question.user_answer(anonymous) == ''
-    assert open_question.user_answer(user1) == answer.answer
+    assert open_question.user_answer(user1) == answer.id
     assert open_question.user_answer(user2) == ''
 
 

--- a/tests/polls/test_question_api.py
+++ b/tests/polls/test_question_api.py
@@ -69,7 +69,8 @@ def test_admin_can_update_poll(apiclient,
                         'is_other_choice': False,
                         'count': 2,
                     },
-                ]
+                ],
+                'answers': [],
             },
             {
                 'label': 'bla',
@@ -87,7 +88,8 @@ def test_admin_can_update_poll(apiclient,
                         'is_other_choice': False,
                         'count': 2
                     },
-                ]
+                ],
+                'answers': [],
             }
         ]
     }
@@ -117,7 +119,8 @@ def test_admin_can_update_poll(apiclient,
                         'is_other_choice': False,
                         'count': 2
                     },
-                ]
+                ],
+                'answers': [],
             }
         ]
     }

--- a/tests/polls/test_validators.py
+++ b/tests/polls/test_validators.py
@@ -30,7 +30,8 @@ def test_choice_belongs_to_question(admin,
 
     data = {
         'choices': [choice2.pk],
-        'other_choice_answer': {}
+        'other_choice_answer': '',
+        'open_answer': ''
     }
 
     with pytest.raises(ValidationError):

--- a/tests/polls/test_vote_api.py
+++ b/tests/polls/test_vote_api.py
@@ -29,7 +29,8 @@ def test_anonymous_user_can_not_vote(apiclient,
 
     data = {
         'choices': [choice1.pk],
-        'other_choice_answer': {}
+        'other_choice_answer': '',
+        'open_answer': ''
     }
 
     response = apiclient.post(url, data, format='json')
@@ -62,7 +63,8 @@ def test_normal_user_can_not_vote(user,
 
     data = {
         'choices': [choice1.pk],
-        'other_choice_answer': {}
+        'other_choice_answer': '',
+        'open_answer': ''
     }
 
     response = apiclient.post(url, data, format='json')
@@ -95,7 +97,8 @@ def test_admin_can_vote(admin,
 
     data = {
         'choices': [choice1.pk],
-        'other_choice_answer': {}
+        'other_choice_answer': '',
+        'open_answer': ''
     }
 
     response = apiclient.post(url, data, format='json')
@@ -128,7 +131,8 @@ def test_normal_user_can_vote_in_active_phase(user,
 
     data = {
         'choices': [choice1.pk],
-        'other_choice_answer': {}
+        'other_choice_answer': '',
+        'open_answer': ''
     }
 
     with active_phase(poll.module, VotingPhase):
@@ -165,7 +169,8 @@ def test_user_cant_vote_in_private_project(user,
 
     data = {
         'choices': [choice1.pk],
-        'other_choice_answer': {}
+        'other_choice_answer': '',
+        'open_answer': ''
     }
 
     with active_phase(poll.module, VotingPhase):
@@ -203,7 +208,8 @@ def test_participant_can_vote_in_private_project(user,
 
     data = {
         'choices': [choice1.pk],
-        'other_choice_answer': {}
+        'other_choice_answer': '',
+        'open_answer': ''
     }
 
     with active_phase(poll.module, VotingPhase):


### PR DESCRIPTION
Tests for new serializers are still missing, but there is a task in taiga and I wanted to wait until we are sure that this is the way to do it.. 

The serialized data can be seen by adding mixinx.RetrieveModelMixin to PollViewSet in polls/api.py . Then /api/polls/pollId shows all questions of the poll (although the vote annotations arent there, as the questions are only annotated in the VoteViewSet and not in the PollViewSet). I tested with Opin, hope it also works in mB :nerd_face: 