### PR TITLE
apps/polls: make sure detail view knows which view to display - fixes…

### DIFF
--- a/adhocracy4/polls/templates/a4polls/poll_detail.html
+++ b/adhocracy4/polls/templates/a4polls/poll_detail.html
@@ -1,9 +1,9 @@
-{% extends "a4projects/project_detail.html" %}
+{% extends extends %}
 {% load react_polls react_comments %}
 
 
 {% block phase_content %}
-    <div class="module-content">
+    <div class="module-content--light">
         <div class="l-wrapper">
             <div class="l-center-8">
                 {% for question in question_list %}
@@ -13,7 +13,7 @@
         </div>
     </div>
     <div class="l-wrapper">
-        <div class="l-center-6">
+        <div class="l-center-8">
             {% react_comments object %}
         </div>
     </div>

--- a/adhocracy4/polls/views.py
+++ b/adhocracy4/polls/views.py
@@ -4,6 +4,7 @@ from django.shortcuts import render_to_response
 from django.views import generic
 
 from adhocracy4.dashboard import mixins as dashboard_mixins
+from adhocracy4.projects.mixins import DisplayProjectOrModuleMixin
 from adhocracy4.projects.mixins import ProjectMixin
 from adhocracy4.rules import mixins as rules_mixins
 
@@ -12,7 +13,8 @@ from . import models
 
 class PollDetailView(ProjectMixin,
                      rules_mixins.PermissionRequiredMixin,
-                     generic.DetailView):
+                     generic.DetailView,
+                     DisplayProjectOrModuleMixin):
     model = models.Poll
     permission_required = 'a4polls.view_poll'
 

--- a/adhocracy4/projects/mixins.py
+++ b/adhocracy4/projects/mixins.py
@@ -133,6 +133,15 @@ class ProjectMixin(generic.base.ContextMixin):
 
 
 class DisplayProjectOrModuleMixin(generic.base.ContextMixin):
+    """Use the appropriate project or module view with timeline/cluster logic.
+
+    On platforms with multiple module projects, this should be used
+    with the phase view to display the module instead of the project
+    detail where appropriate. To do that, the template should extend
+    'extends' instead of a specific base template.
+    This mixin also makes sure the project view is shown with the
+    appropriate timeline tile activated.
+    """
 
     @cached_property
     def url_name(self):


### PR DESCRIPTION
… #743

depending on the timeline and the module clusters, either the project view with or without initial timeline tile or the module view need to be displayed.
This is needed  to work with the timeline/cluster logic made use of in mB.
https://github.com/liqd/a4-meinberlin/commit/a3e568f77c68dfb78845968a044545b212a5ae36
It does not break projects without that logic (opin) as the detail template is overwritten. And there are no multi modules in opin.