### PR TITLE
apps/polls: also show poll before project start

### DIFF
--- a/adhocracy4/polls/rules.py
+++ b/adhocracy4/polls/rules.py
@@ -2,7 +2,6 @@ import rules
 from rules.predicates import is_superuser
 
 from adhocracy4.modules import predicates as module_predicates
-from adhocracy4.projects.predicates import has_context_started
 
 from . import models
 
@@ -14,8 +13,7 @@ rules.add_perm(
 rules.add_perm(
     'a4polls.view_poll',
     (module_predicates.is_project_admin |
-     (module_predicates.is_allowed_view_item &
-      has_context_started))
+     module_predicates.is_allowed_view_item)
 )
 
 rules.add_perm(


### PR DESCRIPTION
to make it behave like other modules, we show the content of the poll also prior to project start.

Does not affect opin, because the content of the participation is always only shown after project start, no matter what the rule is. For other projects it does not make sense to show a 403 because the project hasn't started yet, even though it's already published.