### PR TITLE
polls/models: move error message to label of choice so that it is see…

### DIFF
--- a/adhocracy4/polls/models.py
+++ b/adhocracy4/polls/models.py
@@ -197,7 +197,7 @@ class Choice(models.Model):
     def clean(self, *args, **kwargs):
         if self.question.is_open:
             raise ValidationError({
-                'question': _('Open questions cannot have choices.')
+                'label': _('Open questions cannot have choices.')
             })
         elif self.is_other_choice:
             if self.question.choices.count() == 0:


### PR DESCRIPTION
…n in dashboard

Sorry, forgot this in the other PR.. so this is to actually show the error message in django admin when trying to add a choice to an open question.. I didnt know how else to do it, because I didnt know how to add it to a field of the questions and just adding it to the question wont show it.. so now I added it to the choice :woman_shrugging: 