### PR TITLE
requirements/base: psycopg2 >= 2.9 is incompatible with django 2.2.x

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ djangorestframework==3.12.4
 easy-thumbnails==2.7.1
 html5lib==1.1
 jsonfield==3.1.0
-psycopg2-binary==2.9.1
+psycopg2-binary==2.8.6 # pyup: < 2.9
 python-dateutil==2.8.1
 python-magic==0.4.24
 rules==3.0


### PR DESCRIPTION
psycopg 2.9.x is incompatible with django 2.2.x so pin to the latest release and make pyup ignore it.