### PR TITLE
apps/budgetingmap/maps: fixing inactive pins (safari & FF)

### DIFF
--- a/adhocracy4/maps/static/a4maps/a4maps_choose_polygon.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_choose_polygon.js
@@ -29,7 +29,8 @@ function init () {
       dragging: true,
       scrollWheelZoom: false,
       zoomControl: true,
-      minZoom: 2
+      minZoom: 2,
+      tap: false
     })
 
     const polygonStyle = {

--- a/adhocracy4/maps/static/a4maps/a4maps_common.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_common.js
@@ -18,7 +18,8 @@ export function createMap (L, e, {
     scrollWheelZoom: scrollWheelZoom,
     zoomControl: zoomControl,
     minZoom: minZoom,
-    maxZoom: maxZoom
+    maxZoom: maxZoom,
+    tap: false
   })
 
   if (useVectorMap === '1') {

--- a/adhocracy4/maps/static/a4maps/a4maps_display_points.js
+++ b/adhocracy4/maps/static/a4maps/a4maps_display_points.js
@@ -27,7 +27,8 @@ function init () {
       dragging: true,
       scrollWheelZoom: false,
       zoomControl: false,
-      maxZoom: 18
+      maxZoom: 18,
+      tap: false
     })
 
     map.on('zoomend', function () {


### PR DESCRIPTION
Described in project mB (link to issue):
https://github.com/liqd/a4-meinberlin/issues/3633

A bug in leaflet, which leads to that issue in Safari (and Firefox).
https://github.com/Leaflet/Leaflet/issues/7266