### PR TITLE
apps/polls: only show poll initially when phase active

### DIFF
--- a/adhocracy4/polls/assets/PollQuestions.jsx
+++ b/adhocracy4/polls/assets/PollQuestions.jsx
@@ -219,7 +219,10 @@ class PollQuestions extends React.Component {
 
   componentDidMount () {
     api.poll.get(this.props.pollId)
-      .done(r => this.setState({ questions: r.questions }))
+      .done(r => this.setState({
+        questions: r.questions,
+        showResults: (r.questions.length > 0 && r.questions[0].isReadOnly)
+      }))
   }
 
   render () {
@@ -258,9 +261,13 @@ class PollQuestions extends React.Component {
             )
           ))}
           <Alert onClick={() => this.removeAlert()} {...this.state.alert} />
-          {!this.isReadOnly() && (
+          {!this.isReadOnly() ? (
             <div className="poll poll__button--wrapper">
               {this.buttonVote}{!this.state.loading ? this.linkShowResults : this.loadingIndicator}
+            </div>
+          ) : (
+            <div className="poll">
+              {!this.state.loading ? this.linkShowResults : this.loadingIndicator}
             </div>
           )}
         </div>


### PR DESCRIPTION
This will fix https://github.com/liqd/a4-meinberlin/issues/3736 and https://github.com/liqd/a4-meinberlin/issues/3735 once updated.