### PR TITLE
organisations/predicates: retrun that user is no org group member if …

### DIFF
--- a/adhocracy4/organisations/predicates.py
+++ b/adhocracy4/organisations/predicates.py
@@ -33,6 +33,8 @@ def is_org_group_member(user, subject):
         elif (hasattr(subject, 'organisation') and
               hasattr(subject.organisation, 'groups')):
             organisation = subject.organisation
+        else:
+            return False
         org_groups = organisation.groups.all()
         user_groups = user.groups.all()
         group = org_groups & user_groups


### PR DESCRIPTION
…organisation doesnt have groups

fixes https://sentry.liqd.net/organizations/liqd/issues/1454/?project=8&query=is%3Aunresolved