### PR TITLE
apps/projects: test if field event_type exists in offile event

### DIFF
--- a/adhocracy4/projects/models.py
+++ b/adhocracy4/projects/models.py
@@ -110,7 +110,7 @@ class ModuleClusterPropertiesMixin:
 class TimelinePropertiesMixin:
 
     def get_events_list(self):
-        if self.events:
+        if self.events and hasattr(self.events[0], 'event_type'):
             return self.events.values('date', 'name',
                                       'event_type',
                                       'slug', 'description')


### PR DESCRIPTION
We need this to make the poll detail view work with plattforms with and without timeline.
Once updated will fix https://github.com/liqd/a4-opin/issues/2282