### PR TITLE
exports/mixins: fixed export time difference and test

### DIFF
--- a/adhocracy4/exports/mixins/comments.py
+++ b/adhocracy4/exports/mixins/comments.py
@@ -54,14 +54,14 @@ class ItemExportWithCommentsMixin(VirtualFieldMixin):
     def _flat_comments(self, item):
         for comment in item.comments.all():
             yield self.COMMENT_FMT.format(
-                date=comment.created.isoformat(),
+                date=comment.created.astimezone().isoformat(),
                 username=comment.creator.username,
                 text=unescape_and_strip_html(comment.comment)
             )
 
             for reply in comment.child_comments.all():
                 yield self.REPLY_FMT.format(
-                    date=reply.created.isoformat(),
+                    date=reply.created.astimezone().isoformat(),
                     username=reply.creator.username,
                     text=unescape_and_strip_html(reply.comment)
                 )

--- a/adhocracy4/exports/mixins/general.py
+++ b/adhocracy4/exports/mixins/general.py
@@ -20,7 +20,7 @@ class UserGeneratedContentExportMixin(VirtualFieldMixin):
         return item.creator.username
 
     def get_created_data(self, item):
-        return item.created.isoformat()
+        return item.created.astimezone().isoformat()
 
 
 class ItemExportWithLinkMixin(VirtualFieldMixin):

--- a/tests/exports/mixins/test_general_mixins.py
+++ b/tests/exports/mixins/test_general_mixins.py
@@ -14,7 +14,8 @@ def test_user_generated_content_mixin(idea):
     assert 'created' in virtual
 
     assert idea.creator.username == mixin.get_creator_data(idea)
-    assert idea.created.isoformat() == mixin.get_created_data(idea)
+    assert idea.created.astimezone().isoformat() == \
+           mixin.get_created_data(idea)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes part of #3793, the other one was fixed in a4-meinberlin.