### PR TITLE
fix(deps): update dependency remark-gfm to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-markdown": "6.0.3",
     "react-popper": "2.2.5",
     "react-slick": "0.28.1",
-    "remark-gfm": "1.0.0",
+    "remark-gfm": "2.0.0",
     "slick-carousel": "git+https://github.com/liqd/slick.git#pm-2019-07-overwrites"
   },
   "devDependencies": {


### PR DESCRIPTION
add to other apps on update:
 `   fallback: {
      path: require.resolve('path-browserify'),
      assert: require.resolve('assert/')
    },`