### PR TITLE
apps/polls: use new state to determine which poll link to show

### DIFF
--- a/adhocracy4/polls/assets/PollQuestions.jsx
+++ b/adhocracy4/polls/assets/PollQuestions.jsx
@@ -269,7 +269,7 @@ class PollQuestions extends React.Component {
             />
           ))}
           <div className="poll">
-            {this.hasAnyVotes() ? this.linkChangeVote : this.linkToPoll}
+            {this.state.hasVotes ? this.linkChangeVote : this.linkToPoll}
           </div>
         </div>
         )


### PR DESCRIPTION
This fixes the problem with the showing the result not working at all. 
It was introduced with https://github.com/liqd/adhocracy4/pull/822
But I don't think this works as intended (and before also didn't). But I would like to merge, update and then ask @mcastro-lqd and @CarolingerSeilchenspringer how it should behave. There is also the other slightly weird thing where you can click "view result", even if you changed your vote and then the result is shown, but with the uservote checkmark at the wrong option.