### PR TITLE
Sm 2021 11 blocked comments not shown in discussion

### DIFF
--- a/adhocracy4/comments_async/serializers.py
+++ b/adhocracy4/comments_async/serializers.py
@@ -27,10 +27,12 @@ class CommentSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         """
-        Create a dictionary form categories.
+        Create a dictionary form categories and don't show blocked comments.
 
         Gets the categories and adds them along with their values
         to a dictionary.
+        Also gets the comments and blocks their content
+        from being shown if they are set to blocked.
         """
         ret = super().to_representation(instance)
         categories = {}
@@ -47,6 +49,9 @@ class CommentSerializer(serializers.ModelSerializer):
                 else:
                     categories[category] = category
         ret['comment_categories'] = categories
+        is_blocked = ret.get('is_blocked')
+        if is_blocked:
+            ret['comment'] = ''
         return ret
 
     def to_internal_value(self, data):

--- a/adhocracy4/comments_async/static/comments_async/comment.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment.jsx
@@ -260,6 +260,8 @@ export default class Comment extends React.Component {
       lastDate = django.gettext('Deleted by creator on') + ' ' + localeDate(this.props.modified)
     } else if (this.props.is_censored) {
       lastDate = django.gettext('Deleted by moderator on') + ' ' + localeDate(this.props.modified)
+    } else if (this.props.is_blocked) {
+      lastDate = django.gettext('Blocked by moderator on') + ' ' + localeDate(this.props.modified)
     } else {
       lastDate = django.gettext('Latest edit on') + ' ' + localeDate(this.props.modified)
     }

--- a/adhocracy4/comments_async/static/comments_async/comment_list.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_list.jsx
@@ -25,6 +25,7 @@ export default function (props) {
               is_deleted={comment.is_deleted}
               is_removed={comment.is_removed}
               is_censored={comment.is_censored}
+              is_blocked={comment.is_blocked}
               is_moderator_marked={comment.is_moderator_marked}
               index={index}
               parentIndex={props.parentIndex}


### PR DESCRIPTION
In the 3rd commit:
Changed the mechanism defined in the serializer to block comments from showing in conversation that have been set blocked by moderation. This time it should work correctly.

As of 2nd commit:
Texts of blocked comments are not shown, but marked as blocked instead. Child comments of blocked comments are still displayed:
![image](https://user-images.githubusercontent.com/17978375/140726341-29deaae9-723f-4c88-a7a2-beabb955d8df.png)

As discussed, this is only implemented for async comments.
