### PR TITLE
apps/emails: add organsiation to get_site and report emails

### DIFF
--- a/adhocracy4/emails/base.py
+++ b/adhocracy4/emails/base.py
@@ -21,7 +21,15 @@ class EmailBase:
     # then pass the exception with all mails to `handle_report`
     enable_reporting = False
 
+    def get_organisation(self):
+        return
+
     def get_site(self):
+        organisation = self.get_organisation()
+        if organisation is not None and hasattr(organisation, 'site'):
+            site = organisation.site
+            if site is not None:
+                return site
         if self.site_id is not None:
             return Site.objects.get(pk=self.site_id)
         elif hasattr(settings, 'SITE_ID'):

--- a/adhocracy4/reports/emails.py
+++ b/adhocracy4/reports/emails.py
@@ -7,3 +7,6 @@ User = get_user_model()
 
 class ReportModeratorEmail(emails.ModeratorNotification):
     template_name = 'a4reports/emails/report_moderators'
+
+    def get_organisation(self):
+        return self.object.project.organisation


### PR DESCRIPTION
This even works locally. Because of hasattr, it also works with projects without a site added to the organisation.
I thought about also adding the organisation stuff to the attachments to display another logo for organisation emails like in a+, but as we do not have that in mB, but do have organisation logos there, I decided against that.