### PR TITLE
comments/serializers: add comment_content_type

### DIFF
--- a/adhocracy4/comments_async/serializers.py
+++ b/adhocracy4/comments_async/serializers.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext as _
 from easy_thumbnails.files import get_thumbnailer
 from rest_framework import serializers
@@ -16,13 +17,15 @@ class CommentSerializer(serializers.ModelSerializer):
     is_deleted = serializers.SerializerMethodField()
     ratings = serializers.SerializerMethodField()
     is_moderator = serializers.SerializerMethodField()
+    comment_content_type = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
         read_only_fields = ('modified', 'created', 'id',
                             'user_name', 'user_pk', 'user_image',
                             'user_image_fallback', 'ratings',
-                            'content_type', 'object_pk')
+                            'content_type', 'object_pk',
+                            'comment_content_type')
         exclude = ('creator',)
 
     def to_representation(self, instance):
@@ -144,6 +147,11 @@ class CommentSerializer(serializers.ModelSerializer):
         }
 
         return result
+
+    # used in zt-app, where we can't pass props through template tags
+    # FIXME: this should replace comments_contenttype passed in template tag
+    def get_comment_content_type(self, comment):
+        return ContentType.objects.get_for_model(Comment).pk
 
 
 class CommentListSerializer(CommentSerializer):

--- a/tests/comments/test_async_api.py
+++ b/tests/comments/test_async_api.py
@@ -323,8 +323,7 @@ def test_comment_id_in_list(user, apiclient, question_ct, question):
 
 @pytest.mark.django_db
 def test_fields(user, apiclient, question_ct, question):
-    '''This will need to get adapeted whenever things change'''
-
+    """Adapt this whenever things change."""
     apiclient.force_authenticate(user=user)
     url = reverse(
         'comments_async-list',
@@ -348,7 +347,7 @@ def test_fields(user, apiclient, question_ct, question):
     assert response.data['count'] == 1
 
     commentDict = response.data['results'][0]
-    assert len(commentDict) == 20
+    assert len(commentDict) == 21
     assert 'child_comments' in commentDict
     assert 'comment' in commentDict
     assert 'comment_categories' in commentDict


### PR DESCRIPTION
I didnt replace the now used comments_contenttype that is passed through template tags so far as I thought we can do that when we start working on the comments anyway? So for now, this is just extra..