### PR TITLE
Ks 2022 02 use internal api to fetch comments

### DIFF
--- a/adhocracy4/comments_async/templatetags/react_comments_async.py
+++ b/adhocracy4/comments_async/templatetags/react_comments_async.py
@@ -4,7 +4,6 @@ from django import template
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
-from django.urls import reverse
 from django.utils.html import format_html
 
 from adhocracy4.comments.models import Comment
@@ -34,11 +33,6 @@ def react_comments_async(context, obj, with_categories=False):
     comments_contenttype = ContentType.objects.get_for_model(Comment)
     pk = obj.pk
 
-    comments_api_url = reverse('comments-list',
-                               kwargs={'content_type': contenttype.pk,
-                                       'object_pk': obj.pk}
-                               )
-
     with_categories = bool(with_categories)
 
     comment_category_choices = {}
@@ -59,7 +53,6 @@ def react_comments_async(context, obj, with_categories=False):
                       participant/moderator/org_member
     '''
     attributes = {
-        'commentsApiUrl': comments_api_url,
         'comments_contenttype': comments_contenttype.pk,
         'subjectType': contenttype.pk,
         'subjectId': pk,

--- a/adhocracy4/static/api.js
+++ b/adhocracy4/static/api.js
@@ -84,6 +84,11 @@ const api = (function () {
 
   return {
     comments: {
+      get: function (data) {
+        return _sendRequest('comment', {
+          type: 'GET'
+        }, data)
+      },
       add: function (data) {
         return _sendRequest('comment', {
           type: 'POST'

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   ],
   "dependencies": {
     "@popperjs/core": "2.11.2",
-    "axios": "0.25.0",
     "classnames": "2.3.1",
     "immutability-helper": "3.1.1",
     "jquery": "3.6.0",

--- a/tests/comments/test_async_templatetags.py
+++ b/tests/comments/test_async_templatetags.py
@@ -5,7 +5,6 @@ import re
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
-from django.urls import reverse
 from freezegun import freeze_time
 
 from adhocracy4.test import helpers
@@ -41,18 +40,11 @@ def test_react_rating_anonymous(rf, question, comment):
     with freeze_time('2013-01-02 18:00:00 UTC'):
         user = AnonymousUser()
         props = react_comment_render_for_props(rf, user, question)
-        content_type = ContentType.objects.get_for_model(question)
         comments_content_type = ContentType.objects.get_for_model(comment)
         request = rf.get('/')
         request.user = user
 
-        url = reverse(
-            'comments-list',
-            kwargs={'content_type': content_type.pk,
-                    'object_pk': question.pk})
-
         assert props == {
-            'commentsApiUrl': url,
             'comments_contenttype': comments_content_type.pk,
             'isAuthenticated': False,
             'isModerator': False,
@@ -73,18 +65,11 @@ def test_react_rating_user(rf, user, phase_factory, question_factory,
                                                 AskPhase)
     with helpers.freeze_phase(phase):
         props = react_comment_render_for_props(rf, user, question)
-        content_type = ContentType.objects.get_for_model(question)
         comments_content_type = ContentType.objects.get_for_model(comment)
         request = rf.get('/')
         request.user = user
 
-        url = reverse(
-            'comments-list',
-            kwargs={'content_type': content_type.pk,
-                    'object_pk': question.pk})
-
         assert props == {
-            'commentsApiUrl': url,
             'comments_contenttype': comments_content_type.pk,
             'isAuthenticated': True,
             'isModerator': False,
@@ -127,18 +112,11 @@ def test_react_rating_anonymous_with_categories(rf, question, comment):
         user = AnonymousUser()
         props = react_comment_render_for_props_with_categories(rf, user,
                                                                question)
-        content_type = ContentType.objects.get_for_model(question)
         comments_content_type = ContentType.objects.get_for_model(comment)
         request = rf.get('/')
         request.user = user
 
-        url = reverse(
-            'comments-list',
-            kwargs={'content_type': content_type.pk,
-                    'object_pk': question.pk})
-
         assert props == {
-            'commentsApiUrl': url,
             'comments_contenttype': comments_content_type.pk,
             'isAuthenticated': False,
             'isModerator': False,
@@ -161,18 +139,11 @@ def test_react_rating_user_with_categories(rf, user, phase_factory,
     with helpers.freeze_phase(phase):
         props = react_comment_render_for_props_with_categories(rf, user,
                                                                question)
-        content_type = ContentType.objects.get_for_model(question)
         comments_content_type = ContentType.objects.get_for_model(comment)
         request = rf.get('/')
         request.user = user
 
-        url = reverse(
-            'comments-list',
-            kwargs={'content_type': content_type.pk,
-                    'object_pk': question.pk})
-
         assert props == {
-            'commentsApiUrl': url,
             'comments_contenttype': comments_content_type.pk,
             'isAuthenticated': True,
             'isModerator': False,


### PR DESCRIPTION
There is still one axios call missing here: https://github.com/liqd/adhocracy4/blob/39acf0711aa7a614c596e2ee943f1528a8951ab7/adhocracy4/comments_async/static/comments_async/comment_box.jsx#L452

I wasnt sure how to handle it, because the url comes from pagination. I guess there are 2 options:
1. I could modify pagination that it doesnt return the url, but the page name and then pass that as data and use api.js
2. Or use fetch directly here if that is the long term plan anyway (is it? :))?

What do you think @khamui @phillimorland @fuzzylogic2000 ?

Update: as discussed I now use fetch directly for this.