### PR TITLE
comments_async/date: using '<time>element'

### DIFF
--- a/adhocracy4/comments_async/static/comments_async/comment.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment.jsx
@@ -315,7 +315,9 @@ export default class Comment extends React.Component {
                       : <a href={userProfile}>{this.props.user_name}</a>}
                   </div>
                   {moderatorLabel}
-                  <div className="a4-comments__submission-date">{lastDate}</div>
+                  <time className="a4-comments__submission-date">
+                    {lastDate}
+                  </time>
                 </div>
 
                 <div className="col-1 col-md-1 ms-auto a4-comments__dropdown-container">


### PR DESCRIPTION
it seems that currently only date in jsx is used in `comments_async`.
Not sure if sending two extra fields is the right way? I tried converting it on frontend
but that only works with locale set to 'de'.

fixes #918 

- [x] tested with aplus --> liqd/adhocracy-plus#1739
- [x] tested with mB --> liqd/a4-meinberlin#4231
- [ ] tested with opin