### PR TITLE
test/factories: move follow factory to own file

### DIFF
--- a/adhocracy4/test/factories/__init__.py
+++ b/adhocracy4/test/factories/__init__.py
@@ -9,7 +9,6 @@ from django.contrib.auth.models import User
 
 from adhocracy4 import phases
 from adhocracy4.administrative_districts.models import AdministrativeDistrict
-from adhocracy4.follows import models as follow_models
 from adhocracy4.modules.models import Module
 from adhocracy4.phases.models import Phase
 from adhocracy4.projects.enums import Access
@@ -165,12 +164,3 @@ class AdministrativeDistrictFactory(factory.django.DjangoModelFactory):
         model = AdministrativeDistrict
 
     name = factory.Faker('name')
-
-
-class FollowFactory(factory.django.DjangoModelFactory):
-
-    class Meta:
-        model = follow_models.Follow
-
-    creator = factory.SubFactory(UserFactory)
-    project = factory.SubFactory(ProjectFactory)

--- a/adhocracy4/test/factories/follows.py
+++ b/adhocracy4/test/factories/follows.py
@@ -1,0 +1,15 @@
+import factory
+
+from adhocracy4.follows.models import Follow
+
+from . import ProjectFactory
+from . import UserFactory
+
+
+class FollowFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = Follow
+
+    creator = factory.SubFactory(UserFactory)
+    project = factory.SubFactory(ProjectFactory)

--- a/tests/follows/conftest.py
+++ b/tests/follows/conftest.py
@@ -1,5 +1,5 @@
 from pytest_factoryboy import register
 
-from adhocracy4.test.factories import FollowFactory
+from adhocracy4.test.factories.follows import FollowFactory
 
 register(FollowFactory)


### PR DESCRIPTION
I don't know why I didn't do it like this in the first place. Now also works in again in projects that don't have the a4 follows installed (like opin).