### PR TITLE
comments/serializers: adapt update method of CommentModerateSerialize…

### DIFF
--- a/adhocracy4/comments/serializers.py
+++ b/adhocracy4/comments/serializers.py
@@ -177,6 +177,14 @@ class CommentModerateSerializer(serializers.ModelSerializer):
         return data
 
     def update(self, instance, validated_data):
+        """Update comment instance without changing comment.modified.
+
+        This is essentially copied from
+        rest_framework.serializers.ModelSerializer.update(),
+        only difference is ignore_modified=true when saving the instance.
+        See also here:
+        https://github.com/encode/django-rest-framework/blob/master/rest_framework/serializers.py#L991-L1015
+        """
         serializers.raise_errors_on_nested_writes('update', self,
                                                   validated_data)
         info = model_meta.get_field_info(instance)
@@ -185,13 +193,21 @@ class CommentModerateSerializer(serializers.ModelSerializer):
         # Note that unlike `.create()` we don't need to treat many-to-many
         # relationships as being a special case. During updates we already
         # have an instance pk for the relationships to be associated with.
+        m2m_fields = []
         for attr, value in validated_data.items():
             if attr in info.relations and info.relations[attr].to_many:
-                field = getattr(instance, attr)
-                field.set(value)
+                m2m_fields.append((attr, value))
             else:
                 setattr(instance, attr, value)
+
         instance.save(ignore_modified=True)
+
+        # Note that many-to-many fields are set after updating instance.
+        # Setting m2m fields triggers signals which could potentially change
+        # updated instance and we do not want it to collide with .update()
+        for attr, value in m2m_fields:
+            field = getattr(instance, attr)
+            field.set(value)
 
         return instance
 


### PR DESCRIPTION
…r to fixed version

There was a bugfix in the rest_framework.serializers.ModelSerializer.update():
https://github.com/encode/django-rest-framework/commit/6a95451d72c2e1a87e0c5c1d70b2c21e7daa70ea

Since we copied the old method over, this needed to updated here to get the bugfix.