### PR TITLE
comments/wording: change wording for moderators statement/feedback fo…

### DIFF
--- a/adhocracy4/comments_async/static/comments_async/comment.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment.jsx
@@ -25,8 +25,8 @@ const translated = {
   readLess: django.gettext('Read less'),
   share: django.gettext('Share'),
   report: django.gettext(' Report'),
-  showModStatement: django.gettext('Show moderator\'s statement'),
-  hideModStatement: django.gettext('Hide moderator\'s statement')
+  showModStatement: django.gettext('Show moderator\'s feedback'),
+  hideModStatement: django.gettext('Hide moderator\'s feedback')
 }
 
 function getAnswerForm (hide, number) {


### PR DESCRIPTION
…r comments (used in kosmo)

We decided to have this wording in the next kosmo release. But to get proper translations in a+ transifex and not to forget about it, it's already here!