### PR TITLE
polls/assets/PollQuestions: do not show terms of use checkbox to unau…

### DIFF
--- a/adhocracy4/polls/assets/PollQuestions.jsx
+++ b/adhocracy4/polls/assets/PollQuestions.jsx
@@ -346,7 +346,7 @@ class PollQuestions extends React.Component {
               {!this.isReadOnly()
                 ? (
                   <>
-                    {this.state.useTermsOfUse && !this.state.agreedTermsOfUse &&
+                    {this.state.useTermsOfUse && (this.state.agreedTermsOfUse === false) &&
                       <div className="col-12">
                         <TermsOfUseCheckbox
                           id="terms-of-use"


### PR DESCRIPTION
…thenticated users

As the agreedTermsOfUse is null when the user is not authenticated, the checkbox was also shown to unauthenticated users.