### PR TITLE
comments: move date conversion to own function and use in serializer

### DIFF
--- a/adhocracy4/api/dates.py
+++ b/adhocracy4/api/dates.py
@@ -1,0 +1,19 @@
+from django.template import defaultfilters
+from django.utils import timezone
+
+
+def get_datetime_display(datetime):
+    """Convert datetime instance to localtime and return as str."""
+    local_datetime = timezone.localtime(datetime)
+    local_date = defaultfilters.date(local_datetime)
+    local_time = defaultfilters.time(local_datetime)
+
+    return local_date + ', ' + local_time
+
+
+def get_date_display(datetime):
+    """Convert datetime instance to localtime and return date as str."""
+    local_datetime = timezone.localtime(datetime)
+    local_date = defaultfilters.date(local_datetime)
+
+    return local_date


### PR DESCRIPTION
I moved the date conversion to a function, so we can use it in other places. I guess it would better fit into contrib, but we dont have that in a4, so left it in comments app for now.. could also create contrib folder?