### PR TITLE
comments/models: remove wrong usage of update fields

### DIFF
--- a/adhocracy4/comments/models.py
+++ b/adhocracy4/comments/models.py
@@ -68,11 +68,7 @@ class Comment(base.UserGeneratedContentModel):
             return "{}".format(self.comment)
 
     def save(self, *args, **kwargs):
-        """
-        Change the text of the comment if
-        the comment was marked removed or censored
-        """
-
+        """Change comment.comment if comment was marked removed or censored."""
         self.comment = transforms.clean_html_all(
             self.comment)
 
@@ -80,13 +76,7 @@ class Comment(base.UserGeneratedContentModel):
             self.comment = ''
             self.comment_categories = ''
 
-        # detect if comment text has changed
-        elif self._former_comment != self.comment:
-            if 'update_fields' in kwargs:
-                kwargs['update_fields'].append('comment')
-            else:
-                kwargs['update_fields'] = ['comment']
-
+        # save former comment to detect if comment text has changed
         self._former_comment = self.comment
 
         return super(Comment, self).save(*args, **kwargs)


### PR DESCRIPTION
Turns out that update_fields should be used to specify which model fields are saved, i.e. when specified only those fields will be saved. That is why when comment text was changed, nothing else was saved anymore (was also a problem for categories). 

So we will have to do it differently in KOSMO to detect if the comment text was changed. Following [this](https://stackoverflow.com/a/10299274), my idea would be to compare getattr(instance, '_former_comment') and getattr(instance, 'comment') [here](https://github.com/liqd/a4-kosmo/blob/main/apps/classifications/signals.py#L19) or alternatively make our own signal.. will do that tomorrow!