### PR TITLE
comments/models: update _former_comment after save

### DIFF
--- a/adhocracy4/comments/models.py
+++ b/adhocracy4/comments/models.py
@@ -58,6 +58,7 @@ class Comment(base.UserGeneratedContentModel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # save former comment to detect if comment text has changed
         self._former_comment = transforms.clean_html_all(
             self.comment)
 
@@ -73,13 +74,10 @@ class Comment(base.UserGeneratedContentModel):
             self.comment)
 
         if self.is_removed or self.is_censored:
-            self.comment = ''
+            self.comment = self._former_comment = ''
             self.comment_categories = ''
 
-        # save former comment to detect if comment text has changed
-        self._former_comment = self.comment
-
-        return super(Comment, self).save(*args, **kwargs)
+        super(Comment, self).save(*args, **kwargs)
 
     def get_absolute_url(self):
         if hasattr(self.content_object, 'get_absolute_url'):

--- a/tests/comments/test_model.py
+++ b/tests/comments/test_model.py
@@ -32,9 +32,12 @@ def test_delete_comment(comment_factory, rating_factory):
 def test_save(comment_factory):
     comment_removed = comment_factory(comment='I am not yet removed')
     comment_censored = comment_factory(comment='I am not yet censored')
+    comment_edited = comment_factory(comment='I am not yet edited')
 
     assert comment_removed.comment == 'I am not yet removed'
     assert comment_censored.comment == 'I am not yet censored'
+    assert comment_edited.comment == comment_edited._former_comment \
+           == 'I am not yet edited'
 
     comment_removed.is_removed = True
     comment_removed.save()
@@ -42,9 +45,13 @@ def test_save(comment_factory):
     comment_censored.is_censored = True
     comment_censored.save()
     comment_censored.refresh_from_db()
+    comment_edited.comment = 'I am edited'
+    comment_edited.save()
+    comment_edited.refresh_from_db()
 
-    assert comment_removed.comment == ''
-    assert comment_censored.comment == ''
+    assert comment_removed.comment == comment_removed._former_comment == ''
+    assert comment_censored.comment == comment_censored._former_comment == ''
+    assert not comment_edited.comment == comment_edited._former_comment
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Had to change this again as need to update former_comment after saving :see_no_evil: 

The super.save() does not return anything, so fine to remove the return here, I think.

Used here: https://github.com/liqd/a4-kosmo/pull/268