### PR TITLE
comments_async/serializers//static: serve fallback image in own field

### DIFF
--- a/adhocracy4/comments_async/static/comments_async/comment_list.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_list.jsx
@@ -14,7 +14,7 @@ const CommentList = (props) => {
               user_name={comment.user_name}
               user_pk={comment.user_pk}
               user_profile_url={comment.user_profile_url}
-              user_image={comment.user_image}
+              user_image={comment.user_image ? comment.user_image : comment.user_image_fallback}
               child_comments={comment.child_comments}
               created={comment.created}
               modified={comment.modified}

--- a/tests/comments/test_async_api.py
+++ b/tests/comments/test_async_api.py
@@ -361,7 +361,7 @@ def test_fields(user, apiclient, question_ct, question):
     assert not response.data['use_org_terms_of_use']
 
     commentDict = response.data['results'][0]
-    assert len(commentDict) == 21
+    assert len(commentDict) == 22
     assert 'child_comments' in commentDict
     assert 'comment' in commentDict
     assert 'comment_categories' in commentDict


### PR DESCRIPTION
So we can distinguish if a user image is actually present or not.. 

Unfortunately cant test the fallback_image here, as there is no user model in a4 (or is there a way @fuzzylogic2000 ?), so coverage decreases :neutral_face: But I will add a test in aplus!