### PR TITLE
dashboard/views: add module type in ProjectCreateView

### DIFF
--- a/adhocracy4/dashboard/views.py
+++ b/adhocracy4/dashboard/views.py
@@ -1,4 +1,5 @@
 from django.apps import apps
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.messages.views import SuccessMessageMixin
@@ -92,12 +93,21 @@ class ProjectCreateView(mixins.DashboardBaseMixin,
         return response
 
     def _create_modules_and_phases(self, project):
-        module = module_models.Module(
-            name=self.blueprint.title,
-            description=project.description,
-            weight=1,
-            project=project,
-        )
+        if hasattr(settings, 'A4_BLUEPRINT_TYPES'):
+            module = module_models.Module(
+                name=self.blueprint.title,
+                description=project.description,
+                weight=1,
+                project=project,
+                blueprint_type=self.blueprint.type,
+            )
+        else:
+            module = module_models.Module(
+                name=self.blueprint.title,
+                description=project.description,
+                weight=1,
+                project=project,
+            )
         module.save()
         signals.module_created.send(sender=None,
                                     module=module,

--- a/tests/dashboard/test_blueprint_templates.py
+++ b/tests/dashboard/test_blueprint_templates.py
@@ -1,28 +1,29 @@
 import importlib
 
 import pytest
-from django.conf import settings
 from django.test.utils import override_settings
-from django.utils.module_loading import import_string
+
+from adhocracy4.dashboard.blueprints import get_blueprints
 
 
 @override_settings(A4_BLUEPRINT_TYPES=[('QS', 'questions')])
+@override_settings(A4_DASHBOARD={
+    'BLUEPRINTS': 'tests.project.blueprints_with_type.blueprints'})
 @pytest.mark.django_db
-def test_blueprint_template_with_types_raises_error():
+def test_blueprint_template_with_types():
     # reload blueprints to reinitialize ProjectBlueprint with
     # overridden settings
     bp_module = importlib.import_module('adhocracy4.dashboard.blueprints')
     importlib.reload(bp_module)
-    with pytest.raises(TypeError) as error:
-        import_string(settings.A4_DASHBOARD['BLUEPRINTS'])
-    assert str(error.value).\
-        endswith('missing 1 required positional argument: \'type\'')
+    blueprints = get_blueprints()
+    assert blueprints[0][1]._fields == ('title', 'description', 'content',
+                                        'image', 'settings_model', 'type')
 
 
 @pytest.mark.django_db
 def test_blueprint_template_without_types():
     bp_module = importlib.import_module('adhocracy4.dashboard.blueprints')
     importlib.reload(bp_module)
-    blueprints = import_string(settings.A4_DASHBOARD['BLUEPRINTS'])
+    blueprints = get_blueprints()
     assert blueprints[0][1]._fields == ('title', 'description', 'content',
                                         'image', 'settings_model')

--- a/tests/project/blueprints_with_type.py
+++ b/tests/project/blueprints_with_type.py
@@ -1,0 +1,21 @@
+from django.utils.translation import gettext_lazy as _
+
+from adhocracy4.dashboard.blueprints import ProjectBlueprint
+from tests.apps.questions import phases as question_phases
+
+blueprints = [
+    ('questions',
+     ProjectBlueprint(
+         title='Questions',
+         description=_(
+             'Collect questions first and rate them afterwards.'
+         ),
+         content=[
+             question_phases.AskPhase(),
+             question_phases.RatePhase(),
+         ],
+         image='images/questions.svg',
+         settings_model=None,
+         type='QS',
+     )),
+]


### PR DESCRIPTION
Needed for external projects, bplans and project containers.

Kind of belongs to https://github.com/liqd/a4-meinberlin/pull/4449