### PR TITLE
apps/dashboard: add for_superuser property to module component menu

### DIFF
--- a/adhocracy4/dashboard/__init__.py
+++ b/adhocracy4/dashboard/__init__.py
@@ -126,5 +126,6 @@ class ProjectDashboard:
                     'is_active': is_active,
                     'url': url,
                     'is_complete': is_complete,
+                    'for_superuser_only': component.for_superuser_only,
                 })
         return module_menu or None

--- a/adhocracy4/dashboard/components/__init__.py
+++ b/adhocracy4/dashboard/components/__init__.py
@@ -40,6 +40,7 @@ class DashboardComponent:
     identifier = ''
     weight = 0
     label = ''
+    for_superuser_only = False
 
     def is_effective(self, project_or_module):
         """Return if the component is effective for the current context.

--- a/tests/dashboard/test_project_dashboard.py
+++ b/tests/dashboard/test_project_dashboard.py
@@ -71,7 +71,8 @@ def test_menu(module, dashboard_test_component_factory):
             'label': module_component.label,
             'is_active': True,
             'url': 'mc1_url',
-            'is_complete': True
+            'is_complete': True,
+            'for_superuser_only': False
         }
     ]
 
@@ -88,7 +89,8 @@ def test_menu(module, dashboard_test_component_factory):
                 'label': module_component.label,
                 'is_active': False,
                 'url': 'mc1_url',
-                'is_complete': True
+                'is_complete': True,
+                'for_superuser_only': False
             }],
             'is_complete': True,
         }]


### PR DESCRIPTION
needed for https://github.com/liqd/a4-meinberlin/pull/4484
I thought about making more use of this also here and using it in https://github.com/liqd/adhocracy4/blob/04466cb3b14ca7a952c09e060a6c615c1c9173ae/adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html#L27 
But adding all that complexity in a4, when we don't need it, did not make sense to me.