### PR TITLE
replace template strings with regular string concat

### DIFF
--- a/adhocracy4/comments/static/comments/Comment.jsx
+++ b/adhocracy4/comments/static/comments/Comment.jsx
@@ -156,7 +156,7 @@ class Comment extends React.Component {
     if (this.isOwner() || this.context.isModerator) {
       return (
         <Modal
-          name={`comment_delete_${this.props.id}`}
+          name={'comment_delete_' + this.props.id}
           partials={{ title: confirmDeleteText }}
           handleSubmit={() => this.props.onCommentDelete(this.props.index, this.props.parentIndex)}
           action={deleteTag}
@@ -173,7 +173,7 @@ class Comment extends React.Component {
     return (
       <div className="comment">
         <ReportModal
-          name={`report_comment_${this.props.id}`}
+          name={'report_comment_' + this.props.id}
           title={reportText}
           btnStyle="cta"
           objectId={this.props.id}

--- a/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
+++ b/adhocracy4/comments/static/comments/CommentManageDropdown.jsx
@@ -21,10 +21,10 @@ const CommentManageDropdown = (props) => {
               <button type="button" onClick={props.handleToggleEdit}>{editTag}</button>
             </li>,
             <li className="divider" key="2" />,
-            <li key="3"><a href={`#comment_delete_${props.id}`} data-bs-toggle="modal">{deleteTag}</a></li>,
+            <li key="3"><a href={'#comment_delete_' + props.id} data-bs-toggle="modal">{deleteTag}</a></li>,
             <li className="divider" key="4" />
           ]}
-          <li><a href={`#report_comment_${props.id}`} data-bs-toggle="modal">{reportTag}</a>
+          <li><a href={'#report_comment_' + props.id} data-bs-toggle="modal">{reportTag}</a>
           </li>
         </ul>
       </li>

--- a/adhocracy4/comments_async/static/comments_async/comment.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment.jsx
@@ -262,7 +262,7 @@ export default class Comment extends React.Component {
     if (this.props.has_deleting_permission) {
       return (
         <Modal
-          name={`comment_delete_${this.props.id}`}
+          name={'comment_delete_' + this.props.id}
           partials={{ title: django.gettext('Do you really want to delete this comment?') }}
           handleSubmit={() => this.props.onCommentDelete(this.props.index, this.props.parentIndex)}
           action={django.gettext('Delete')}
@@ -274,7 +274,7 @@ export default class Comment extends React.Component {
   }
 
   getCommentUrl () {
-    return window.location.href.split('?')[0].split('#')[0] + '?comment=' + `${this.props.id}`
+    return window.location.href.split('?')[0].split('#')[0] + '?comment=' + this.props.id
   }
 
   render () {
@@ -313,16 +313,16 @@ export default class Comment extends React.Component {
         {this.state.displayNotification &&
           <div className="alert alert--success a4-comments__success-notification"><i className="fas fa-check" /> {translated.successMessage}</div>}
         <div className={(this.props.is_users_own_comment ? 'a4-comments__comment a4-comments__comment-owner' : 'a4-comments__comment')}>
-          <a className="a4-comments__anchor" id={`comment_${this.props.id}`} href={`./?comment=${this.props.id}`}>{`Comment ${this.props.id}`}</a>
+          <a className="a4-comments__anchor" id={'comment_' + this.props.id} href={'./?comment=' + this.props.id}>{'Comment ' + this.props.id}</a>
           <ReportModal
-            name={`report_comment_${this.props.id}`}
+            name={'report_comment_' + this.props.id}
             title={translated.reportTitle}
             btnStyle="cta"
             objectId={this.props.id}
             contentType={this.props.comment_content_type}
           />
           <UrlModal
-            name={`share_comment_${this.props.id}`}
+            name={'share_comment_' + this.props.id}
             title={translated.shareLink}
             btnStyle="cta"
             objectId={this.props.id}
@@ -417,14 +417,14 @@ export default class Comment extends React.Component {
 
                   {!this.props.is_deleted &&
                     <a
-                      className="btn btn--no-border a4-comments__action-bar__btn" href={`?comment_${this.props.id}`}
-                      data-bs-toggle="modal" data-bs-target={`#share_comment_${this.props.id}`}
+                      className="btn btn--no-border a4-comments__action-bar__btn" href={'?comment_' + this.props.id}
+                      data-bs-toggle="modal" data-bs-target={'#share_comment_' + this.props.id}
                     ><i className="fas fa-share" /> {translated.share}
                     </a>}
 
                   {!this.props.is_deleted && this.props.authenticated_user_pk && !this.props.is_users_own_comment &&
                     <a
-                      className="btn btn--no-border a4-comments__action-bar__btn" href={`#report_comment_${this.props.id}`}
+                      className="btn btn--no-border a4-comments__action-bar__btn" href={'#report_comment_' + this.props.id}
                       data-bs-toggle="modal"
                     ><i className="fas fa-exclamation-triangle" />{translated.report}
                     </a>}

--- a/adhocracy4/comments_async/static/comments_async/comment.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment.jsx
@@ -26,19 +26,29 @@ const translated = {
   share: django.gettext('Share'),
   report: django.gettext(' Report'),
   showModStatement: django.gettext('Show moderator\'s feedback'),
-  hideModStatement: django.gettext('Hide moderator\'s feedback')
+  hideModStatement: django.gettext('Hide moderator\'s feedback'),
+  deleteComment: django.gettext('Do you really want to delete this comment?'),
+  delete: django.gettext('Delete'),
+  abort: django.gettext('Abort'),
+  deletedyByCreatorOn: django.gettext('Deleted by creator on'),
+  deletedByModeratorOn: django.gettext('Deleted by moderator on'),
+  blockedByModeratorOn: django.gettext('Blocked by moderator on'),
+  lastEditOn: django.gettext('Latest edit on'),
+  moderator: django.gettext('Moderator'),
+  hideReplies: django.gettext('hide replies'),
+  reply: django.pgettext('verb', 'Reply')
 }
 
 function getAnswerForm (hide, number) {
   let result
   if (hide) {
-    result = django.gettext('hide replies')
+    result = translated.hideReplies
   } else {
     if (number > 0) {
       const tmp = django.ngettext('1 reply', '%s replies', number)
       result = django.interpolate(tmp, [number])
     } else {
-      result = django.pgettext('verb', 'Reply')
+      result = translated.reply
     }
   }
   return result
@@ -263,10 +273,10 @@ export default class Comment extends React.Component {
       return (
         <Modal
           name={'comment_delete_' + this.props.id}
-          partials={{ title: django.gettext('Do you really want to delete this comment?') }}
+          partials={{ title: translated.deleteComment }}
           handleSubmit={() => this.props.onCommentDelete(this.props.index, this.props.parentIndex)}
-          action={django.gettext('Delete')}
-          abort={django.gettext('Abort')}
+          action={translated.delete}
+          abort={translated.abort}
           btnStyle="cta"
         />
       )
@@ -282,18 +292,18 @@ export default class Comment extends React.Component {
     if (this.props.modified === null) {
       lastDate = this.props.created
     } else if (this.props.is_removed) {
-      lastDate = django.gettext('Deleted by creator on') + ' ' + this.props.modified
+      lastDate = translated.deletedyByCreatorOn + ' ' + this.props.modified
     } else if (this.props.is_censored) {
-      lastDate = django.gettext('Deleted by moderator on') + ' ' + this.props.modified
+      lastDate = translated.deletedByModeratorOn + ' ' + this.props.modified
     } else if (this.props.is_blocked) {
-      lastDate = django.gettext('Blocked by moderator on') + ' ' + this.props.modified
+      lastDate = translated.blockedByModeratorOn + ' ' + this.props.modified
     } else {
-      lastDate = django.gettext('Latest edit on') + ' ' + this.props.modified
+      lastDate = translated.lastEditOn + ' ' + this.props.modified
     }
 
     let moderatorLabel
     if (this.props.authorIsModerator && !this.props.is_deleted) {
-      moderatorLabel = <span className="a4-comments__moderator">{django.gettext('Moderator')}</span>
+      moderatorLabel = <span className="a4-comments__moderator">{translated.moderator}</span>
     }
 
     let userImage

--- a/adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx
@@ -98,7 +98,7 @@ export default class CommentCategoryEditForm extends React.Component {
         </div>
         {this.props.useTermsOfUse && !this.props.agreedTermsOfUse &&
           <TermsOfUseCheckbox
-            id={`terms-of-use-${this.props.commentId}`}
+            id={'terms-of-use-' + this.props.commentId}
             onChange={val => this.setState({ checkedTermsOfUse: val })}
             orgTermsUrl={this.props.orgTermsUrl}
           />}

--- a/adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx
@@ -75,7 +75,7 @@ export default class CommentEditForm extends React.Component {
         </div>
         {this.props.useTermsOfUse && !this.props.agreedTermsOfUse &&
           <TermsOfUseCheckbox
-            id={`terms-of-use-${this.props.commentId}`}
+            id={'terms-of-use-' + this.props.commentId}
             onChange={val => this.setState({ checkedTermsOfUse: val })}
             orgTermsUrl={this.props.orgTermsUrl}
           />}

--- a/adhocracy4/comments_async/static/comments_async/comment_form.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_form.jsx
@@ -145,7 +145,7 @@ export default class CommentForm extends React.Component {
                 </label>
                 {this.props.useTermsOfUse && !this.state.agreedTermsOfUse &&
                   <TermsOfUseCheckbox
-                    id={`terms-of-use-checkbox-${typeof this.props.parentIndex === 'number' ? this.props.parentIndex : 'rootForm'}`}
+                    id={'terms-of-use-checkbox-' + typeof this.props.parentIndex === 'number' ? this.props.parentIndex : 'rootForm'}
                     onChange={val => this.setState({ checkedTermsOfUse: val })}
                     orgTermsUrl={this.props.orgTermsUrl}
                   />}

--- a/adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx
@@ -25,7 +25,7 @@ const CommentManageDropdown = (props) => {
           <div className="divider" key="2" />
         ]}
         {props.has_deleting_permission && [
-          <a key="3" className="dropdown-item" href={`#comment_delete_${props.id}`} data-bs-toggle="modal">{translated.delete}</a>,
+          <a key="3" className="dropdown-item" href={'#comment_delete_' + props.id} data-bs-toggle="modal">{translated.delete}</a>,
           <div className="divider" key="4" />
         ]}
       </div>

--- a/adhocracy4/comments_async/static/modals/moderate_modal.jsx
+++ b/adhocracy4/comments_async/static/modals/moderate_modal.jsx
@@ -47,7 +47,7 @@ export default class ModerateModal extends React.Component {
 
     return (
       <Modal
-        name={`comment_moderate_${this.props.id}`}
+        name={'comment_moderate_' + this.props.id}
         partials={partials}
         handleSubmit={() => this.props.onCommentModerate(data, this.props.index, this.props.parentIndex)}
         action={django.gettext('Submit')}

--- a/adhocracy4/polls/static/PollDashboard/EditPollOpenQuestion.jsx
+++ b/adhocracy4/polls/static/PollDashboard/EditPollOpenQuestion.jsx
@@ -31,11 +31,11 @@ export const EditPollOpenQuestion = (props) => {
           ? <HelptextForm id={props.id} question={props.question} onHelptextChange={props.onHelptextChange} errors={props.errors} />
           : null}
         <button
-          className={`btn ${hasHelptext ? 'poll__btn--dark' : 'poll__btn--light'}`}
+          className={'btn ' + hasHelptext ? 'poll__btn--dark' : 'poll__btn--light'}
           onClick={() => setHasHelptext(!hasHelptext)}
           type="button"
         >
-          <i className={`fa ${hasHelptext ? 'fa-check' : 'fa-plus'}`} /> {django.gettext('Explanation')}
+          <i className={'fa +' + hasHelptext ? 'fa-check' : 'fa-plus'} /> {django.gettext('Explanation')}
         </button>
       </div>
 

--- a/adhocracy4/polls/static/PollDashboard/EditPollQuestion.jsx
+++ b/adhocracy4/polls/static/PollDashboard/EditPollQuestion.jsx
@@ -68,7 +68,7 @@ export const EditPollQuestion = (props) => {
           {
             props.question.choices.map((choice, index) => {
               const key = choice.id || choice.key
-              const label = django.pgettext('noun', 'Answer') + ` #${index + 1}`
+              const label = django.pgettext('noun', 'Answer') + ' #' + (index + 1)
               const errors = props.errors && props.errors.choices
                 ? props.errors.choices[index]
                 : {}
@@ -114,11 +114,11 @@ export const EditPollQuestion = (props) => {
             <i className="fa fa-plus" /> {django.gettext('New answer')}
           </button>
           <button
-            className={`btn ${hasHelptext ? 'poll__btn--dark' : 'poll__btn--light'}`}
+            className={'btn ' + hasHelptext ? 'poll__btn--dark' : 'poll__btn--light'}
             onClick={() => setHasHelptext(!hasHelptext)}
             type="button"
           >
-            <i className={`fa ${hasHelptext ? 'fa-check' : 'fa-plus'}`} /> {django.gettext('Explanation')}
+            <i className={'fa ' + hasHelptext ? 'fa-check' : 'fa-plus'} /> {django.gettext('Explanation')}
           </button>
         </div>
       </div>

--- a/adhocracy4/ratings/static/ratings/react_ratings.jsx
+++ b/adhocracy4/ratings/static/ratings/react_ratings.jsx
@@ -118,7 +118,7 @@ class RatingBox extends React.Component {
   render () {
     const getRatingClasses = ratingType => {
       const valueForRatingType = ratingType === 'up' ? 1 : -1
-      return classnames(`rating-button rating-${ratingType}`, {
+      return classnames('rating-button rating-' + ratingType, {
         'is-selected': this.state.userRating === valueForRatingType
       })
     }

--- a/adhocracy4/static/Alert.jsx
+++ b/adhocracy4/static/Alert.jsx
@@ -16,7 +16,7 @@ const Alert = ({ type, alertAttribute, message, onClick, timeInMs }) => {
     return (
       <div
         id="alert"
-        className={`alert alert--${type}`}
+        className={'alert alert--' + type}
         aria-atomic="true"
         aria-live={alertAttribute}
       >


### PR DESCRIPTION
This will fix the issue with the disappearing translations. Template strings like `some string ${someVar}` will break our translations so we should avoid them