### PR TITLE
filters: when invalid filter value, use default value if there is one

### DIFF
--- a/adhocracy4/filters/filters.py
+++ b/adhocracy4/filters/filters.py
@@ -63,6 +63,11 @@ class DefaultsFilterSet(PagedFilterSet):
                 data[key] = value
         super().__init__(data, *args, **kwargs)
 
+        # if filter has invalid value, set it to default value
+        for field in self.form.errors:
+            if field in self.data and field in self.defaults:
+                self.data[field] = self.defaults[field]
+
 
 class DistinctOrderingFilter(django_filters.OrderingFilter):
     """Makes sure, that every queryset gets a distinct ordering.


### PR DESCRIPTION
When the filter argument is invalid, django adds and shows the label 'All', also in the case that this isnt a 'real' choice. 
With this, it would now use the default value of the filter if there is one. 