### PR TITLE
Replace liqd/django-autoslug dependency with upstream

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 bleach[css]==6.0.0
 Django==3.2.19
 django-allauth==0.54.0
-git+https://github.com/liqd/django-autoslug.git@liqd2212#egg=django-autoslug
+django-autoslug==1.9.9
 django-background-tasks==1.2.5
 django-ckeditor==6.5.1
 django-enumfield==3.1


### PR DESCRIPTION
## Overview

This PR replaces the [forked/edited django-autoslug](https://github.com/liqd/django-autoslug) (introduced via #1302) with its original upstream.

This is possible now as the changes made on the forked repo are [merged and released upstream](https://github.com/justinmayer/django-autoslug/pull/79#issuecomment-1494295682).

## Manual testing

**Able to install the latest upstream django-autoslug via pip**
![image](https://github.com/liqd/adhocracy-plus/assets/16653571/045d5239-1b15-4658-a149-2a340b5bfdde)