### PR TITLE
[7428] projects: add intial_slide to view context of module detail views

### DIFF
--- a/adhocracy4/projects/mixins.py
+++ b/adhocracy4/projects/mixins.py
@@ -171,6 +171,10 @@ class DisplayProjectOrModuleMixin(generic.base.ContextMixin):
             context["event"] = self.get_current_event()
             context["modules"] = self.get_current_modules()
             context["initial_slide"] = self.initial_slide
+        else:
+            context["initial_slide"] = self.project.get_module_cluster_index(
+                self.module
+            )
         return context
 
 

--- a/adhocracy4/projects/models.py
+++ b/adhocracy4/projects/models.py
@@ -152,6 +152,14 @@ class TimelinePropertiesMixin:
             return []
         return []
 
+    def get_module_cluster_index(self, module):
+        for idx, val in enumerate(self.participation_dates):
+            if "modules" in val and module in val["modules"]:
+                return idx
+        if self.project.get_current_participation_date():
+            return self.project.get_current_participation_date()
+        return 0
+
 
 class Project(
     ProjectContactDetailMixin,

--- a/changelog/7428.md
+++ b/changelog/7428.md
@@ -1,0 +1,3 @@
+### Added
+
+- added initial_slide to context of module detail views


### PR DESCRIPTION
Ok, this story is actually still in the backlog, was checking it together with @goapunk to see if is good for onboarding, but seemed a bit too complicated to find the right places.
But maybe @m4ra and @hklarnerliqd can review :) It needs another part in Aplus, will also tag you there!