### PR TITLE
comments_async: make fetchComments take arguments instead of relying

### DIFF
--- a/adhocracy4/models/query.py
+++ b/adhocracy4/models/query.py
@@ -32,4 +32,5 @@ class CommentableQuerySet(models.QuerySet):
                 "comments",
                 distinct=True,  # needed to combine with other count annotations
             )
+            + models.Count("comments__child_comments", distinct=True)
         )

--- a/changelog/0004.md
+++ b/changelog/0004.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- fixed comment infinite scrolling not working
+- fixed anchor links and scrollTo not working when comment was not on the first
+  pagination page
+- fix comment count not including child comments on module tiles, lists, map
+  pins and detail view

--- a/tests/comments/test_async_api.py
+++ b/tests/comments/test_async_api.py
@@ -356,7 +356,7 @@ def test_fields(user, apiclient, question_ct, question):
 
     response = apiclient.get(url)
 
-    assert len(response.data) == 8
+    assert len(response.data) == 9
     assert "count" in response.data
     assert "next" in response.data
     assert "previous" in response.data

--- a/tests/comments/test_async_api_org_terms.py
+++ b/tests/comments/test_async_api_org_terms.py
@@ -245,7 +245,7 @@ def test_agreement_info(
     )
 
     response = apiclient.get(url)
-    assert len(response.data) == 10
+    assert len(response.data) == 11
     assert "use_org_terms_of_use" in response.data
     assert response.data["use_org_terms_of_use"]
     assert "user_has_agreed" in response.data
@@ -256,13 +256,13 @@ def test_agreement_info(
     # user has agreed
     apiclient.force_authenticate(user=user)
     response = apiclient.get(url)
-    assert len(response.data) == 10
+    assert len(response.data) == 11
     assert response.data["user_has_agreed"]
 
     # another_user has not agreed
     apiclient.force_authenticate(user=another_user)
     response = apiclient.get(url)
-    assert len(response.data) == 10
+    assert len(response.data) == 11
     assert not response.data["user_has_agreed"]
 
 


### PR DESCRIPTION
on state variables. Should fix the issue with the scrolling not working when an anchor is passed.