### PR TITLE
comments_async/comment_form: remove un-used string to stop translatio…

### DIFF
--- a/adhocracy4/comments_async/static/comments_async/comment_form.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_form.jsx
@@ -14,7 +14,6 @@ const translated = {
   yourReply: django.gettext('Your reply'),
   characters: django.gettext(' characters'),
   post: django.gettext('post'),
-  comment: django.gettext('Comment'),
   pleaseComment: django.gettext('Please login to comment'),
   onlyInvited: django.gettext('Only invited users can actively participate.'),
   notAllowedComment: django.gettext('The currently active phase doesn\'t allow to comment.'),


### PR DESCRIPTION
…n errors with plurals

**Tasks**
- [x] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
