### PR TITLE
comments_async/comment_box: fix comment count plural not updating pro…

### DIFF
--- a/adhocracy4/comments_async/static/comments_async/comment_box.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_box.jsx
@@ -107,7 +107,6 @@ export const CommentBox = (props) => {
   function handleComments (result) {
     const data = result
 
-    translated.entries = django.ngettext('entry', 'entries', data.count)
     setComments(data.results)
     setNextComments(data.next)
     setCommentCount(data.comment_count)
@@ -409,6 +408,13 @@ export const CommentBox = (props) => {
     }
   }
 
+  function translatedEntries (entries) {
+    return django.ngettext(
+      'entry',
+      'entries', entries
+    )
+  }
+
   function translatedEntriesFound (entriesFound) {
     return django.ngettext(
       'entry found for ',
@@ -472,7 +478,7 @@ export const CommentBox = (props) => {
           <div
             className={search === '' ? 'a4-comments__filters__text' : 'd-none'}
           >
-            {commentCount + ' ' + translated.entries}
+            {commentCount + ' ' + translatedEntries(commentCount)}
           </div>
 
           <div

--- a/changelog/_4444.md
+++ b/changelog/_4444.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix comment count plurals not updating properly


### PR DESCRIPTION
…perly

The comment count (on proposals for example) would only have the correct plural after refreshing. This should fix it

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
