### PR TITLE
projects/TimelinePropertiesMixin: add check if module has a project s…

### DIFF
--- a/adhocracy4/projects/models.py
+++ b/adhocracy4/projects/models.py
@@ -177,7 +177,7 @@ class TimelinePropertiesMixin:
         for idx, val in enumerate(self.participation_dates):
             if "modules" in val and module in val["modules"]:
                 return idx
-        if self.project.get_current_participation_date():
+        if hasattr(self, "project") and self.project.get_current_participation_date():
             return self.project.get_current_participation_date()
         return 0
 

--- a/changelog/_5555.md
+++ b/changelog/_5555.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- fix an error when opening a module which is marked as draft in a multimodule
+  project


### PR DESCRIPTION
…et to prevent a crash for modules marked as draft

testing: without this fix, if you go to the django-admin -> modules and mark a module as draft and then click on show on website you will get a 500 in multimodule projects (default with the local fixtures).

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
