### PR TITLE
ci: remove frontend coverage test

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -83,8 +83,3 @@ jobs:
       - name: Run Frontend Tests
         run: |
           npm test
-      - name: Frontend Coverage
-        uses: artiomtr/jest-coverage-report-action@v2.0-rc.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'pull_request'


### PR DESCRIPTION
It's quite slow and not super helpful, if we want the coverage in github we should probably find something else. We already removed it in the other projects

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
