### PR TITLE
dashboard/mixins: change form_valid back to delete in

### DIFF
--- a/adhocracy4/dashboard/mixins.py
+++ b/adhocracy4/dashboard/mixins.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 
 from django.apps import apps
@@ -107,21 +108,32 @@ class DashboardComponentMixin(base.ContextMixin):
 
 
 class DashboardComponentFormSignalMixin(edit.FormMixin):
+    """Mixin which sends a project_component_updated or module_component_updated signal
+    when creating, updating or deleting an object via the HTTP POST method
+    (e.g. from the dashboard).
+    """
+
     def form_valid(self, form):
+        # The call to super.form_valid() may delete self.project or self.module,
+        # to be able to still reference them below we need to store them in separate
+        # variables before they are deleted.
+        project = self.project
+        module = self.module
+
         response = super().form_valid(form)
 
         component = self.component
         if component.identifier in components.projects:
             signals.project_component_updated.send(
                 sender=component.__class__,
-                project=self.project,
+                project=project,
                 component=component,
                 user=self.request.user,
             )
         else:
             signals.module_component_updated.send(
                 sender=component.__class__,
-                module=self.module,
+                module=module,
                 component=component,
                 user=self.request.user,
             )
@@ -129,13 +141,34 @@ class DashboardComponentFormSignalMixin(edit.FormMixin):
 
 
 class DashboardComponentDeleteSignalMixin(edit.DeletionMixin):
-    def form_valid(self, request, *args, **kwargs):
+    """Deprecated, use DashboardComponentFormSignalMixin for POST requests instead.
+    This mixin will be removed in the next version.
+    """
+
+    def __init__(self):
+        warnings.warn(
+            "dashboard.mixins.DashboardComponentDeleteSignalMixin is deprecated, "
+            "use dashboard.mixins.DashboardComponentFormSignalMixin for forms / POST "
+            "requests. This mixin will be removed in the next version.",
+            DeprecationWarning,
+        )
+
+        super().__init__()
+
+    def delete(self, request, *args, **kwargs):
+        warnings.warn(
+            "dashboard.mixins.DashboardComponentDeleteSignalMixin.delete()"
+            "is deprecated, use dashboard.mixins.DashboardComponentFormSignalMixin "
+            "for forms / POST requests. This mixin will be removed in the next "
+            "version.",
+            DeprecationWarning,
+        )
         # Project and module have to be stored before delete is called as
         # they may rely on the still existing db object.
         project = self.project
         module = self.module
 
-        response = super().form_valid(request, *args, **kwargs)
+        response = super().delete(request, *args, **kwargs)
 
         component = self.component
         if component.identifier in components.projects:

--- a/changelog/_00010.md
+++ b/changelog/_00010.md
@@ -1,0 +1,7 @@
+### Changed
+
+- **Breaking Change** Deprecated
+  dashboard.mixins.DashboardComponentDeleteSignalMixin,
+  for forms / POST requests use
+  dashboard.mixins.DashboardComponentFormSignalMixin instead.
+  DashboardComponentDeleteSignalMixin will be removed in the next version.

--- a/tests/actions/factories.py
+++ b/tests/actions/factories.py
@@ -21,3 +21,4 @@ class ActionFactory(factory.django.DjangoModelFactory):
     def project(obj, create, extracted, **kwargs):
         if obj.obj:
             obj.project = obj.obj.project
+            obj.save()


### PR DESCRIPTION
DashboardComponentDeleteSignalMixin and add documentation.

**Tasks**
- [ ] PR name contains story or task reference
- [x] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
