### PR TITLE
dashboard/mixins.py: add missing args and kwargs

### DIFF
--- a/adhocracy4/dashboard/mixins.py
+++ b/adhocracy4/dashboard/mixins.py
@@ -147,7 +147,7 @@ class DashboardComponentDeleteSignalMixin(edit.DeletionMixin):
     This mixin will be removed in the next version.
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         warnings.warn(
             "dashboard.mixins.DashboardComponentDeleteSignalMixin is deprecated, "
             "use dashboard.mixins.DashboardComponentFormSignalMixin for forms / POST "
@@ -155,7 +155,7 @@ class DashboardComponentDeleteSignalMixin(edit.DeletionMixin):
             DeprecationWarning,
         )
 
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
     def delete(self, request, *args, **kwargs):
         warnings.warn(


### PR DESCRIPTION
fixes `FAILED tests/maptopicprio/dashboard_components/test_views_module_maptopics.py::test_maptopic_delete_view - TypeError: __init__() got an unexpected keyword argument 'component'`

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
