### PR TITLE
comments_async/comment_form.jsx: capitalize buttons cta

### DIFF
--- a/adhocracy4/comments_async/static/comments_async/comment_form.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_form.jsx
@@ -14,11 +14,11 @@ const translated = {
   errorComment: django.gettext('Something seems to have gone wrong, please try again.'),
   yourReply: django.gettext('Your reply'),
   characters: django.gettext(' characters'),
-  post: django.gettext('post'),
+  post: django.gettext('Post'),
   pleaseComment: django.gettext('Please login to comment'),
   onlyInvited: django.gettext('Only invited users can actively participate.'),
   notAllowedComment: django.gettext('The currently active phase doesn\'t allow to comment.'),
-  cancel: django.gettext('cancel')
+  cancel: django.gettext('Cancel')
 }
 
 export default class CommentForm extends React.Component {


### PR DESCRIPTION
**Description**
Capitalize buttons copy on comments app

not sure this need changelog

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
