### PR TITLE
maps_react: fix indetermined execution order causing the polygon

### DIFF
--- a/adhocracy4/maps_react/static/a4maps_react/__tests__/Map.jest.jsx
+++ b/adhocracy4/maps_react/static/a4maps_react/__tests__/Map.jest.jsx
@@ -30,7 +30,7 @@ jest.mock('react-leaflet', () => {
   MapContainer.displayName = 'MapContainer'
 
   const GeoJSON = React.forwardRef((props, ref) => (
-    <div data-testid="geojson"><ActualReactLeaflet.GeoJSON ref={ref} props={props} /></div>
+    <div data-testid="geojson" />
   ))
   GeoJSON.displayName = 'GeoJSON'
 
@@ -50,6 +50,9 @@ describe('Map component tests', () => {
     expect(mapNode).toBeTruthy()
   })
 
+  // FIXME: test is broken as before this commit the polygon callback would
+  // return because map is null, since this commit the map works as intended but
+  // polygon.getBounds() returns null and hence map.fitBounds() fails.
   test('renders map with GeoJSON when polygon prop is provided', () => {
     render(<Map polygon={polygonData} />)
     const geoJsonNode = screen.getByTestId('geojson')


### PR DESCRIPTION
callback to be executed before the map object is created. Instead of relying on the refs, use the useMap hook and conditional rendering for the polygon.

Not sure if this is the best approach but for now it makes the maps work again on design-dev

fixes https://github.com/liqd/a4-meinberlin/issues/5582

to reproduce the error add the following to your `webpack.dev.js`:
```
module.exports = merge(common, {
    devtool: 'eval-source-map',
    optimization: {
       'nodeEnv': 'production'
     }                                    
})                                                                          
```
and try to create a mapidea or proposal

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
