### PR TITLE
categories: make icon form field optional 

### DIFF
--- a/adhocracy4/categories/forms.py
+++ b/adhocracy4/categories/forms.py
@@ -51,7 +51,7 @@ class CategoryForm(forms.ModelForm):
             del self.fields["icon"]
 
     name = forms.CharField(widget=forms.TextInput(attrs={"placeholder": _("Category")}))
-    icon = CategoryChoiceField()
+    icon = CategoryChoiceField(required=False)
 
     class Media:
         js = ("category_formset.js",)

--- a/changelog/_1111.md
+++ b/changelog/_1111.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- categories: make the icon form field optional, fixes category form not
+  accepting a category without icon.

--- a/tests/categories/conftest.py
+++ b/tests/categories/conftest.py
@@ -1,6 +1,8 @@
 from pytest_factoryboy import register
 
 from adhocracy4.test.factories import categories as category_factories
+from adhocracy4.test.factories.maps import AreaSettingsFactory
 
 register(category_factories.CategoryFactory)
 register(category_factories.CategoryAliasFactory)
+register(AreaSettingsFactory)

--- a/tests/categories/test_form.py
+++ b/tests/categories/test_form.py
@@ -1,0 +1,53 @@
+import pytest
+
+from adhocracy4.categories.forms import CategoryForm
+
+
+@pytest.mark.django_db
+def test_category_form_empty_name(area_settings):
+    module = area_settings.module
+    form = CategoryForm(
+        module=module,
+        data={
+            "name": "",
+        },
+    )
+    assert "name" in form.errors
+    assert "icon" not in form.errors
+    assert not form.is_valid()
+
+
+@pytest.mark.django_db
+def test_category_form_invalid_icon(area_settings):
+    module = area_settings.module
+    form = CategoryForm(
+        module=module,
+        data={"name": "category 1", "icon": "XX"},
+    )
+    assert "name" not in form.errors
+    assert "icon" in form.errors
+    assert not form.is_valid()
+
+
+@pytest.mark.django_db
+def test_category_form_empty_icon(area_settings):
+    module = area_settings.module
+    form = CategoryForm(
+        module=module,
+        data={"name": "category 1", "icon": ""},
+    )
+    assert "name" not in form.errors
+    assert "icon" not in form.errors
+    assert form.is_valid()
+
+
+@pytest.mark.django_db
+def test_category_form_valid_icon(area_settings):
+    module = area_settings.module
+    form = CategoryForm(
+        module=module,
+        data={"name": "category 1", "icon": "diamant"},
+    )
+    assert "name" not in form.errors
+    assert "icon" not in form.errors
+    assert form.is_valid()

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -168,7 +168,23 @@ A4_AUTO_FOLLOWABLES = (("a4comments", "comment"),)
 A4_CATEGORIZABLE = (("a4test_questions", "question"),)
 A4_LABELS_ADDABLE = (("a4test_questions", "question"),)
 A4_DASHBOARD = {"BLUEPRINTS": "tests.project.blueprints.blueprints"}
-
+A4_CATEGORY_ICONS = (
+    ("", ("Pin without icon")),
+    ("diamant", ("Diamond")),
+    ("dreieck_oben", ("Triangle up")),
+    ("dreieck_unten", ("Triangle down")),
+    ("ellipse", ("Ellipse")),
+    ("halbkreis", ("Semi circle")),
+    ("hexagon", ("Hexagon")),
+    ("parallelogramm", ("Rhomboid")),
+    ("pentagramm", ("Star")),
+    ("quadrat", ("Square")),
+    ("raute", ("Octothorpe")),
+    ("rechtecke", ("Rectangle")),
+    ("ring", ("Circle")),
+    ("rw_dreieck", ("Right triangle")),
+    ("zickzack", ("Zigzag")),
+)
 
 # Rich text fields
 


### PR DESCRIPTION
 make icon form field optional  to allow categories without icon

fixes https://github.com/liqd/adhocracy-plus/issues/2580 and the same issue in mb

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
