### PR TITLE
static/Modal.jsx: fix modal not closing on comment deletion

### DIFF
--- a/adhocracy4/static/Modal.jsx
+++ b/adhocracy4/static/Modal.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import django from 'django'
 
 const Modal = (props) => {
-  const dismiss = props.dismissOnSubmit ? 'modal' : 'false'
   const abortStr = props.abort || django.gettext('Abort')
   const bodyCssClass = props.partials.bodyClass || ''
 
@@ -29,7 +28,6 @@ const Modal = (props) => {
               className="close"
               aria-label={abortStr}
               data-bs-dismiss="modal"
-              onClick={props.handleClose}
             >
               <i className="fa fa-times" aria-hidden="true" />
             </button>
@@ -47,7 +45,7 @@ const Modal = (props) => {
             <div className="modal-footer">
               <button
                 className="submit-button"
-                data-bs-dismiss={dismiss}
+                data-bs-dismiss="modal"
                 onClick={props.handleSubmit}
               >
                 {props.action}
@@ -55,7 +53,6 @@ const Modal = (props) => {
               <button
                 className="cancel-button"
                 data-bs-dismiss="modal"
-                onClick={props.handleClose}
               >
                 {abortStr}
               </button>


### PR DESCRIPTION
fixes https://github.com/liqd/adhocracy4/issues/1588 & https://github.com/liqd/adhocracy-plus/issues/2565
Fix undefined props error in button functionality and replace handleClose method with Bootstrap's `data-bs-dismiss` for modal closing
