### PR TITLE
comments_async/ai_report: make wording for ai report toggle button mo…

### DIFF
--- a/adhocracy4/comments_async/static/comments_async/ai_report.jsx
+++ b/adhocracy4/comments_async/static/comments_async/ai_report.jsx
@@ -10,8 +10,8 @@ const translated = {
   ariaReadLess: django.pgettext('defakts', 'Click to hide the AI explanation for reporting this comment.'),
   readMore: django.pgettext('defakts', 'Read more'),
   showLess: django.pgettext('defakts', 'Show less'),
-  showInfoSwitch: django.pgettext('defakts', 'Show info to users'),
-  hideInfoSwitch: django.pgettext('defakts', 'Hide info from users')
+  showInfoSwitch: django.pgettext('defakts', 'Show AI info to users'),
+  hideInfoSwitch: django.pgettext('defakts', 'Hide AI info from users')
 }
 
 export const AiReport = ({ Report, notificationPk, toggleShowAiReport }) => {

--- a/changelog/_1111.md
+++ b/changelog/_1111.md
@@ -1,0 +1,3 @@
+### Changed
+
+- make wording for ai report toggle more specific


### PR DESCRIPTION
…re specific

fixes #https://github.com/liqd/a4-defakts/issues/48 

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
