### PR TITLE
comments_async: fix some issues with child comments

### DIFF
--- a/adhocracy4/comments_async/static/comments_async/comment.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment.jsx
@@ -164,6 +164,7 @@ export default class Comment extends React.Component {
       comment = (
         // Edit comment form
         <CommentForm
+          editing
           subjectType={this.props.content_type}
           subjectId={this.props.object_pk}
           comment={this.props.children}
@@ -421,6 +422,8 @@ export default class Comment extends React.Component {
                       comments={this.props.child_comments}
                       anchoredCommentId={this.props.anchoredCommentId}
                       anchoredCommentParentId={this.props.anchoredCommentParentId}
+                      hasCommentingPermission={this.props.hasCommentingPermission}
+                      wouldHaveCommentingPermission={this.props.wouldHaveCommentingPermission}
                       parentIndex={this.props.index}
                       onRenderFinished={this.props.onRenderFinished}
                       onCommentDelete={this.props.onCommentDelete}

--- a/adhocracy4/comments_async/static/comments_async/comment_form.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_form.jsx
@@ -138,7 +138,8 @@ export default class CommentForm extends React.Component {
     if (this.props.hasCommentingPermission) {
       return (
         <>
-          <h3 className="a4-comments__comment-form__heading-comments-allowed">{translated.formHeadingCommentsAllowed}</h3>
+          {!this.props.editing &&
+            <h3 className="a4-comments__comment-form__heading-comments-allowed">{translated.formHeadingCommentsAllowed}</h3>}
           <form id={'id-comment-form' + this.props.commentId} className="a4-comments__comment-form__form" onSubmit={this.handleSubmit.bind(this)}>
             {this.props.error &&
               <Alert type="danger" message={this.props.errorMessage} onClick={this.props.handleErrorClick} />}

--- a/changelog/_1113.md
+++ b/changelog/_1113.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- comments_async: fix child comments not being editable by creator
+- comments_async: hide "Join the discussion" headline when editing
+  a comment


### PR DESCRIPTION
- fix child comments not being editable by creator
- hide comment form headline when editing

fixes #https://github.com/liqd/adhocracy-plus/issues/2716

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
