### PR TITLE
comments_async: display correct message for private group users

### DIFF
--- a/adhocracy4/comments_async/static/comments_async/__tests__/__snapshots__/comment_box.jest.jsx.snap
+++ b/adhocracy4/comments_async/static/comments_async/__tests__/__snapshots__/comment_box.jest.jsx.snap
@@ -10,7 +10,7 @@ exports[`CommentBox Component comments are fetched and loading spinners is hidde
           class="a4-comments__commentbox__form"
         >
           <div>
-            Only invited users can actively participate.
+            The currently active phase doesn't allow to comment.
           </div>
         </div>
         <div>
@@ -157,7 +157,7 @@ exports[`CommentBox Component comments are fetched and loading spinners is hidde
         class="a4-comments__commentbox__form"
       >
         <div>
-          Only invited users can actively participate.
+          The currently active phase doesn't allow to comment.
         </div>
       </div>
       <div>

--- a/adhocracy4/comments_async/static/comments_async/comment_form.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_form.jsx
@@ -231,7 +231,7 @@ export default class CommentForm extends React.Component {
           <a href={config.getLoginUrl()}>{translated.pleaseComment}</a>
         </div>
       )
-    } else if (!this.props.projectIsPublic) {
+    } else if (!this.props.projectIsPublic && this.state.agreedTermsOfUse) {
       return (
         <div>
           {translated.onlyInvited}


### PR DESCRIPTION
fixes : https://github.com/liqd/adhocracy4/issues/1043

steps to reproduce: https://github.com/liqd/adhocracy4/issues/1043#issuecomment-2301842120