### PR TITLE
Makefile: fix broken pytest-lastfailed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ pytest:
 	$(VIRTUAL_ENV)/bin/py.test --reuse-db
 
 .PHONY: pytest-lastfailed
-test-lastfailed:
+pytest-lastfailed:
 	$(VIRTUAL_ENV)/bin/py.test --reuse-db --last-failed
 
 .PHONY: pytest-clean


### PR DESCRIPTION
Makefile command was broken, this fixes it.

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
