### PR TITLE
static/Captcha: add react specific classes to some fields to prevent

### DIFF
--- a/adhocracy4/static/Captcha.jsx
+++ b/adhocracy4/static/Captcha.jsx
@@ -115,7 +115,7 @@ const CaptCheck = ({ apiUrl, name, onChange, refresh }) => {
               )
             : (
               <label
-                className="captcheck_question_access"
+                className="captcheck_question_access react_captcha"
                 id={'captcheck_' + captcha.id_prefix + '_question_access'}
               >
                 {captcha.question_a + ' = ?'}
@@ -134,7 +134,7 @@ const CaptCheck = ({ apiUrl, name, onChange, refresh }) => {
               isImageMode ? translated.ariaLabelText : translated.ariaLabelImage
             }
           >
-            {isImageMode ? translated.imageMode : translated.textMode}
+            {isImageMode ? translated.textMode : translated.imageMode}
           </a>
         </div>
 
@@ -179,13 +179,13 @@ const CaptCheck = ({ apiUrl, name, onChange, refresh }) => {
               )
             : (
               <div
-                className="captcheck_answer_access"
+                className="captcheck_answer_access react_captcha"
                 id={'captcheck_' + captcha.id_prefix + '_answer_access'}
               >
                 <input
                   id={
                   'captcheck_' + captcha.id_prefix + '_question_access-answer'
-                }
+                  }
                   type="text"
                   name="captcheck_selected_answer"
                   aria-label="Type your answer here."


### PR DESCRIPTION
the text mode from not showing due to the styling for the plain js captcha.

to be tested with https://github.com/liqd/adhocracy-plus/pull/2841

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
