### PR TITLE
polls: add new django setting to enable or disable the unregistered poll

### DIFF
--- a/adhocracy4/polls/serializers.py
+++ b/adhocracy4/polls/serializers.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework import serializers
 
 from adhocracy4.dashboard import components
@@ -153,7 +154,12 @@ class PollSerializer(serializers.ModelSerializer):
         return False
 
     def update(self, instance, data):
-        instance.allow_unregistered_users = data.get("allow_unregistered_users", False)
+        if getattr(settings, "A4_POLL_ENABLE_UNREGISTERED_USERS", False):
+            instance.allow_unregistered_users = data.get(
+                "allow_unregistered_users", False
+            )
+        else:
+            instance.allow_unregistered_users = False
         instance.save()
         # Delete removed questions from the database
         instance.questions.exclude(

--- a/adhocracy4/polls/static/PollDashboard/EditPollManagement.jsx
+++ b/adhocracy4/polls/static/PollDashboard/EditPollManagement.jsx
@@ -208,10 +208,11 @@ export const EditPollManagement = (props) => {
       onSubmit={(e) => handleSubmit(e)} onChange={() => removeAlert()}
       className="editpoll__questions"
     >
-      <div>
-        <label htmlFor="allowUnregisteredUsersCheckbox">Allow unregistered user to vote</label>
-        <input type="checkbox" id="allowUnregisteredUsersCheckbox" onChange={() => setAllowUnregisteredUsers((state) => !state)} checked={allowUnregisteredUsers} />
-      </div>
+      {props.enableUnregisteredUsers &&
+        <div>
+          <label htmlFor="allowUnregisteredUsersCheckbox">Allow unregistered user to vote</label>
+          <input type="checkbox" id="allowUnregisteredUsersCheckbox" onChange={() => setAllowUnregisteredUsers((state) => !state)} checked={allowUnregisteredUsers} />
+        </div>}
       <FlipMove easing="cubic-bezier(0.25, 0.5, 0.75, 1)">
         {
           questions.map((question, index, arr) => {

--- a/adhocracy4/polls/static/react_poll_management.jsx
+++ b/adhocracy4/polls/static/react_poll_management.jsx
@@ -7,13 +7,11 @@ import { EditPollManagement } from './PollDashboard/EditPollManagement'
 function init () {
   ReactWidgetInit('a4', 'poll-management',
     function (el) {
-      const pollId = el.dataset.pollId
+      const props = JSON.parse(el.dataset.attributes)
       const root = createRoot(el)
 
-      const reloadOnSuccess = JSON.parse(el.getAttribute('data-reloadOnSuccess'))
-
       root.render(
-        <EditPollManagement pollId={pollId} reloadOnSuccess={reloadOnSuccess} />
+        <EditPollManagement {...props} />
       )
     }
   )

--- a/adhocracy4/polls/templatetags/react_polls.py
+++ b/adhocracy4/polls/templatetags/react_polls.py
@@ -21,14 +21,16 @@ def react_polls(poll: Poll):
 
 @register.simple_tag
 def react_poll_form(poll, reload_on_success=False):
+    attributes = {
+        "pollId": poll.pk,
+        "reloadOnSuccess": reload_on_success,
+        "enableUnregisteredUsers": getattr(
+            settings, "A4_POLL_ENABLE_UNREGISTERED_USERS", False
+        ),
+    }
     reload_on_success = json.dumps(reload_on_success)
 
     return format_html(
-        (
-            '<div data-a4-widget="poll-management" data-poll-id="{pollId}" '
-            ' data-reloadOnSuccess="{reload_on_success}">'
-            "</div>"
-        ),
-        pollId=poll.pk,
-        reload_on_success=reload_on_success,
+        '<div data-a4-widget="poll-management" data-attributes="{attributes}"></div>',
+        attributes=json.dumps(attributes),
     )

--- a/changelog/8381.md
+++ b/changelog/8381.md
@@ -1,0 +1,6 @@
+### Added
+
+- add option to allow unregistered users to vote in a poll:
+  - the feature is controlled via a new django setting `A4_POLL_ENABLE_UNREGISTERED_USERS` to enable or disable it
+- add a new captcha react component to integrate the captcha in the poll
+


### PR DESCRIPTION
voting

- add missing changelog

required to e.g. disable it in meinBerlin for now (or other forks of a+)

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
