### PR TITLE
[#8527] E-Mail attachment setting

### DIFF
--- a/changelog/8527.md
+++ b/changelog/8527.md
@@ -1,0 +1,3 @@
+### Added
+- new setting `A4_EMAIL_ATTACHMENTS` if you need more than the `email_logo.png` attachement in your emails
+  - this allows you to add custom attachments to the emails, even those set in a4


### PR DESCRIPTION
Add new setting `A4_EMAIL_ATTACHMENTS` for when you need more than the `email_logo.png` attachment in your emails.

No breaking change as a fallback is included when the setting is not existing.

See https://github.com/liqd/a4-meinberlin/pull/5908 for usage

**Tasks**
- [x] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
