### PR TITLE
static/Modal.jsx refactor: migrate from Bootstrap to native dialog element adapt to mB redesign

### DIFF
--- a/adhocracy4/comments/static/comments/Comment.jsx
+++ b/adhocracy4/comments/static/comments/Comment.jsx
@@ -1,12 +1,12 @@
+const React = require('react')
+const django = require('django')
+
+const { default: Modal } = require('../../../static/Modal')
 const ReportModal = require('../../../reports/static/reports/react_reports').ReportModal
 const RatingBox = require('../../../ratings/static/ratings/RatingBox')
-const Modal = require('../../../static/Modal')
 const CommentEditForm = require('./CommentEditForm')
 const CommentForm = require('./CommentForm')
 const CommentManageDropdown = require('./CommentManageDropdown')
-
-const React = require('react')
-const django = require('django')
 
 const safeHtml = function (text) {
   return { __html: text }
@@ -156,7 +156,6 @@ class Comment extends React.Component {
     if (this.isOwner() || this.context.isModerator) {
       return (
         <Modal
-          name={'comment_delete_' + this.props.id}
           partials={{
             title: deleteTag,
             description: confirmDeleteText

--- a/adhocracy4/comments_async/static/comments_async/__tests__/__snapshots__/comment.jest.jsx.snap
+++ b/adhocracy4/comments_async/static/comments_async/__tests__/__snapshots__/comment.jest.jsx.snap
@@ -140,11 +140,8 @@ exports[`Comment Component renders comment with creator and comment text 1`] = `
                       Reply
                     </a>
                   </button>
-                  <a
-                    class="btn btn--no-border a4-comments__action-bar__btn"
-                    data-bs-target="#share_comment_1"
-                    data-bs-toggle="modal"
-                    href="?comment_1"
+                  <button
+                    class="a4-modal__toggle btn-link link"
                   >
                     <i
                       aria-hidden="true"
@@ -152,140 +149,6 @@ exports[`Comment Component renders comment with creator and comment text 1`] = `
                     />
                      
                     Share
-                  </a>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          aria-hidden="true"
-          aria-label="Send Report"
-          class="modal fade"
-          id="report_comment_1"
-          role="dialog"
-          tabindex="-1"
-        >
-          <div
-            class="modal-dialog modal-dialog-centered modal-lg"
-            role="document"
-          >
-            <div
-              class="modal-content"
-            >
-              <div
-                class="modal-header"
-              >
-                <h2
-                  class="u-no-margin-bottom u-spacer-top-one-half"
-                >
-                  Send Report
-                </h2>
-                <button
-                  aria-label="Abort"
-                  class="close"
-                  data-bs-dismiss="modal"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="fa fa-times"
-                  />
-                </button>
-              </div>
-              <div
-                class="modal-body "
-              >
-                <div
-                  class="u-spacer-bottom"
-                >
-                  You want to report this content? Your message will be sent to the moderation. The moderation will look at the reported content. The content will be deleted if it does not meet our discussion rules (netiquette).
-                </div>
-                <div
-                  class="form-group"
-                >
-                  <textarea
-                    class="form-control report-message"
-                    placeholder="Your message"
-                    rows="5"
-                  />
-                </div>
-              </div>
-              <div
-                class="modal-footer"
-              >
-                <button
-                  class="submit-button"
-                  data-bs-dismiss="false"
-                >
-                  Send Report
-                </button>
-                <button
-                  class="cancel-button"
-                  data-bs-dismiss="modal"
-                >
-                  Abort
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          aria-hidden="true"
-          aria-label="Share link"
-          class="modal fade"
-          id="share_comment_1"
-          role="dialog"
-          tabindex="-1"
-        >
-          <div
-            class="modal-dialog modal-dialog-centered modal-lg"
-            role="document"
-          >
-            <div
-              class="modal-content"
-            >
-              <div
-                class="modal-header"
-              >
-                <h2
-                  class="u-no-margin-bottom u-spacer-top-one-half"
-                >
-                  Share link
-                </h2>
-                <button
-                  aria-label="Abort"
-                  class="close"
-                  data-bs-dismiss="modal"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="fa fa-times"
-                  />
-                </button>
-              </div>
-              <div
-                class="modal-body "
-              >
-                <div
-                  class="u-spacer-bottom"
-                />
-                <div
-                  class="input-group"
-                >
-                  <input
-                    class="form-control"
-                    id="share-url-1"
-                    readonly=""
-                    type="text"
-                    value="http://localhost/?comment=1"
-                  />
-                  <button
-                    aria-pressed="false"
-                    autocomplete="off"
-                    class="btn btn--primary input-group-append"
-                    data-bs-toggle="button"
-                  >
-                    Copy
                   </button>
                 </div>
               </div>
@@ -294,6 +157,56 @@ exports[`Comment Component renders comment with creator and comment text 1`] = `
         </div>
       </li>
     </div>
+    <dialog
+      class="a4-modal"
+      id=":r0:"
+    >
+      <div
+        class="a4-modal__content"
+      >
+        <header
+          class="a4-modal__header"
+        >
+          <h2
+            class="a4-modal__title"
+          >
+            Share link
+          </h2>
+          <button
+            aria-label="Close"
+            class="a4-modal__close"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="fa fa-times"
+            />
+          </button>
+        </header>
+        <div
+          class="a4-modal__body "
+        >
+          <div
+            class="input-group a4-url-modal__body"
+          >
+            <input
+              class="form-control"
+              id="share-url-undefined"
+              readonly=""
+              type="text"
+              value="http://localhost/?comment=1"
+            />
+            <button
+              aria-pressed="false"
+              autocomplete="off"
+              class="a4-url-modal__button"
+            >
+              Copy
+            </button>
+          </div>
+        </div>
+      </div>
+    </dialog>
   </body>,
   "container": <div>
     <li>
@@ -431,11 +344,8 @@ exports[`Comment Component renders comment with creator and comment text 1`] = `
                     Reply
                   </a>
                 </button>
-                <a
-                  class="btn btn--no-border a4-comments__action-bar__btn"
-                  data-bs-target="#share_comment_1"
-                  data-bs-toggle="modal"
-                  href="?comment_1"
+                <button
+                  class="a4-modal__toggle btn-link link"
                 >
                   <i
                     aria-hidden="true"
@@ -443,140 +353,6 @@ exports[`Comment Component renders comment with creator and comment text 1`] = `
                   />
                    
                   Share
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        aria-hidden="true"
-        aria-label="Send Report"
-        class="modal fade"
-        id="report_comment_1"
-        role="dialog"
-        tabindex="-1"
-      >
-        <div
-          class="modal-dialog modal-dialog-centered modal-lg"
-          role="document"
-        >
-          <div
-            class="modal-content"
-          >
-            <div
-              class="modal-header"
-            >
-              <h2
-                class="u-no-margin-bottom u-spacer-top-one-half"
-              >
-                Send Report
-              </h2>
-              <button
-                aria-label="Abort"
-                class="close"
-                data-bs-dismiss="modal"
-              >
-                <i
-                  aria-hidden="true"
-                  class="fa fa-times"
-                />
-              </button>
-            </div>
-            <div
-              class="modal-body "
-            >
-              <div
-                class="u-spacer-bottom"
-              >
-                You want to report this content? Your message will be sent to the moderation. The moderation will look at the reported content. The content will be deleted if it does not meet our discussion rules (netiquette).
-              </div>
-              <div
-                class="form-group"
-              >
-                <textarea
-                  class="form-control report-message"
-                  placeholder="Your message"
-                  rows="5"
-                />
-              </div>
-            </div>
-            <div
-              class="modal-footer"
-            >
-              <button
-                class="submit-button"
-                data-bs-dismiss="false"
-              >
-                Send Report
-              </button>
-              <button
-                class="cancel-button"
-                data-bs-dismiss="modal"
-              >
-                Abort
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        aria-hidden="true"
-        aria-label="Share link"
-        class="modal fade"
-        id="share_comment_1"
-        role="dialog"
-        tabindex="-1"
-      >
-        <div
-          class="modal-dialog modal-dialog-centered modal-lg"
-          role="document"
-        >
-          <div
-            class="modal-content"
-          >
-            <div
-              class="modal-header"
-            >
-              <h2
-                class="u-no-margin-bottom u-spacer-top-one-half"
-              >
-                Share link
-              </h2>
-              <button
-                aria-label="Abort"
-                class="close"
-                data-bs-dismiss="modal"
-              >
-                <i
-                  aria-hidden="true"
-                  class="fa fa-times"
-                />
-              </button>
-            </div>
-            <div
-              class="modal-body "
-            >
-              <div
-                class="u-spacer-bottom"
-              />
-              <div
-                class="input-group"
-              >
-                <input
-                  class="form-control"
-                  id="share-url-1"
-                  readonly=""
-                  type="text"
-                  value="http://localhost/?comment=1"
-                />
-                <button
-                  aria-pressed="false"
-                  autocomplete="off"
-                  class="btn btn--primary input-group-append"
-                  data-bs-toggle="button"
-                >
-                  Copy
                 </button>
               </div>
             </div>
@@ -784,11 +560,8 @@ exports[`Comment Component renders comment with moderator badge 1`] = `
                       Reply
                     </a>
                   </button>
-                  <a
-                    class="btn btn--no-border a4-comments__action-bar__btn"
-                    data-bs-target="#share_comment_1"
-                    data-bs-toggle="modal"
-                    href="?comment_1"
+                  <button
+                    class="a4-modal__toggle btn-link link"
                   >
                     <i
                       aria-hidden="true"
@@ -796,140 +569,6 @@ exports[`Comment Component renders comment with moderator badge 1`] = `
                     />
                      
                     Share
-                  </a>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          aria-hidden="true"
-          aria-label="Send Report"
-          class="modal fade"
-          id="report_comment_1"
-          role="dialog"
-          tabindex="-1"
-        >
-          <div
-            class="modal-dialog modal-dialog-centered modal-lg"
-            role="document"
-          >
-            <div
-              class="modal-content"
-            >
-              <div
-                class="modal-header"
-              >
-                <h2
-                  class="u-no-margin-bottom u-spacer-top-one-half"
-                >
-                  Send Report
-                </h2>
-                <button
-                  aria-label="Abort"
-                  class="close"
-                  data-bs-dismiss="modal"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="fa fa-times"
-                  />
-                </button>
-              </div>
-              <div
-                class="modal-body "
-              >
-                <div
-                  class="u-spacer-bottom"
-                >
-                  You want to report this content? Your message will be sent to the moderation. The moderation will look at the reported content. The content will be deleted if it does not meet our discussion rules (netiquette).
-                </div>
-                <div
-                  class="form-group"
-                >
-                  <textarea
-                    class="form-control report-message"
-                    placeholder="Your message"
-                    rows="5"
-                  />
-                </div>
-              </div>
-              <div
-                class="modal-footer"
-              >
-                <button
-                  class="submit-button"
-                  data-bs-dismiss="false"
-                >
-                  Send Report
-                </button>
-                <button
-                  class="cancel-button"
-                  data-bs-dismiss="modal"
-                >
-                  Abort
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          aria-hidden="true"
-          aria-label="Share link"
-          class="modal fade"
-          id="share_comment_1"
-          role="dialog"
-          tabindex="-1"
-        >
-          <div
-            class="modal-dialog modal-dialog-centered modal-lg"
-            role="document"
-          >
-            <div
-              class="modal-content"
-            >
-              <div
-                class="modal-header"
-              >
-                <h2
-                  class="u-no-margin-bottom u-spacer-top-one-half"
-                >
-                  Share link
-                </h2>
-                <button
-                  aria-label="Abort"
-                  class="close"
-                  data-bs-dismiss="modal"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="fa fa-times"
-                  />
-                </button>
-              </div>
-              <div
-                class="modal-body "
-              >
-                <div
-                  class="u-spacer-bottom"
-                />
-                <div
-                  class="input-group"
-                >
-                  <input
-                    class="form-control"
-                    id="share-url-1"
-                    readonly=""
-                    type="text"
-                    value="http://localhost/?comment=1"
-                  />
-                  <button
-                    aria-pressed="false"
-                    autocomplete="off"
-                    class="btn btn--primary input-group-append"
-                    data-bs-toggle="button"
-                  >
-                    Copy
                   </button>
                 </div>
               </div>
@@ -938,6 +577,56 @@ exports[`Comment Component renders comment with moderator badge 1`] = `
         </div>
       </li>
     </div>
+    <dialog
+      class="a4-modal"
+      id=":r4:"
+    >
+      <div
+        class="a4-modal__content"
+      >
+        <header
+          class="a4-modal__header"
+        >
+          <h2
+            class="a4-modal__title"
+          >
+            Share link
+          </h2>
+          <button
+            aria-label="Close"
+            class="a4-modal__close"
+            type="button"
+          >
+            <i
+              aria-hidden="true"
+              class="fa fa-times"
+            />
+          </button>
+        </header>
+        <div
+          class="a4-modal__body "
+        >
+          <div
+            class="input-group a4-url-modal__body"
+          >
+            <input
+              class="form-control"
+              id="share-url-undefined"
+              readonly=""
+              type="text"
+              value="http://localhost/?comment=1"
+            />
+            <button
+              aria-pressed="false"
+              autocomplete="off"
+              class="a4-url-modal__button"
+            >
+              Copy
+            </button>
+          </div>
+        </div>
+      </div>
+    </dialog>
   </body>,
   "container": <div>
     <li>
@@ -1080,11 +769,8 @@ exports[`Comment Component renders comment with moderator badge 1`] = `
                     Reply
                   </a>
                 </button>
-                <a
-                  class="btn btn--no-border a4-comments__action-bar__btn"
-                  data-bs-target="#share_comment_1"
-                  data-bs-toggle="modal"
-                  href="?comment_1"
+                <button
+                  class="a4-modal__toggle btn-link link"
                 >
                   <i
                     aria-hidden="true"
@@ -1092,140 +778,6 @@ exports[`Comment Component renders comment with moderator badge 1`] = `
                   />
                    
                   Share
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        aria-hidden="true"
-        aria-label="Send Report"
-        class="modal fade"
-        id="report_comment_1"
-        role="dialog"
-        tabindex="-1"
-      >
-        <div
-          class="modal-dialog modal-dialog-centered modal-lg"
-          role="document"
-        >
-          <div
-            class="modal-content"
-          >
-            <div
-              class="modal-header"
-            >
-              <h2
-                class="u-no-margin-bottom u-spacer-top-one-half"
-              >
-                Send Report
-              </h2>
-              <button
-                aria-label="Abort"
-                class="close"
-                data-bs-dismiss="modal"
-              >
-                <i
-                  aria-hidden="true"
-                  class="fa fa-times"
-                />
-              </button>
-            </div>
-            <div
-              class="modal-body "
-            >
-              <div
-                class="u-spacer-bottom"
-              >
-                You want to report this content? Your message will be sent to the moderation. The moderation will look at the reported content. The content will be deleted if it does not meet our discussion rules (netiquette).
-              </div>
-              <div
-                class="form-group"
-              >
-                <textarea
-                  class="form-control report-message"
-                  placeholder="Your message"
-                  rows="5"
-                />
-              </div>
-            </div>
-            <div
-              class="modal-footer"
-            >
-              <button
-                class="submit-button"
-                data-bs-dismiss="false"
-              >
-                Send Report
-              </button>
-              <button
-                class="cancel-button"
-                data-bs-dismiss="modal"
-              >
-                Abort
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        aria-hidden="true"
-        aria-label="Share link"
-        class="modal fade"
-        id="share_comment_1"
-        role="dialog"
-        tabindex="-1"
-      >
-        <div
-          class="modal-dialog modal-dialog-centered modal-lg"
-          role="document"
-        >
-          <div
-            class="modal-content"
-          >
-            <div
-              class="modal-header"
-            >
-              <h2
-                class="u-no-margin-bottom u-spacer-top-one-half"
-              >
-                Share link
-              </h2>
-              <button
-                aria-label="Abort"
-                class="close"
-                data-bs-dismiss="modal"
-              >
-                <i
-                  aria-hidden="true"
-                  class="fa fa-times"
-                />
-              </button>
-            </div>
-            <div
-              class="modal-body "
-            >
-              <div
-                class="u-spacer-bottom"
-              />
-              <div
-                class="input-group"
-              >
-                <input
-                  class="form-control"
-                  id="share-url-1"
-                  readonly=""
-                  type="text"
-                  value="http://localhost/?comment=1"
-                />
-                <button
-                  aria-pressed="false"
-                  autocomplete="off"
-                  class="btn btn--primary input-group-append"
-                  data-bs-toggle="button"
-                >
-                  Copy
                 </button>
               </div>
             </div>

--- a/adhocracy4/comments_async/static/comments_async/comment.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment.jsx
@@ -20,14 +20,11 @@ const translated = {
   successMessage: django.gettext('Entry successfully created'),
   readMore: django.gettext('Read more...'),
   readLess: django.gettext('Read less'),
-  share: django.gettext('Share'),
-  report: django.gettext(' Report'),
   showModStatement: django.gettext('Show moderator\'s feedback'),
   hideModStatement: django.gettext('Hide moderator\'s feedback'),
   deleteCommentQuestion: django.gettext('Do you really want to delete this comment?'),
   deleteComment: django.gettext('Delete comment'),
   delete: django.gettext('Delete'),
-  abort: django.gettext('Abort'),
   deletedyByCreatorOn: django.gettext('Deleted by creator on'),
   deletedByModeratorOn: django.gettext('Deleted by moderator on'),
   blockedByModerator: django.gettext('Blocked by moderator'),
@@ -255,24 +252,6 @@ export default class Comment extends React.Component {
     }
   }
 
-  renderDeleteModal () {
-    if (this.props.has_deleting_permission) {
-      return (
-        <Modal
-          name={'comment_delete_' + this.props.id}
-          partials={{
-            title: translated.deleteComment,
-            description: translated.deleteCommentQuestion
-          }}
-          handleSubmit={() => this.props.onCommentDelete(this.props.index, this.props.parentIndex)}
-          action={translated.delete}
-          abort={translated.abort}
-          btnStyle="cta"
-        />
-      )
-    }
-  }
-
   getCommentUrl () {
     return window.location.href.split('?')[0].split('#')[0] + '?comment=' + this.props.id
   }
@@ -308,12 +287,39 @@ export default class Comment extends React.Component {
 
     const userProfile = this.props.user_profile_url
 
+    const modals = {
+      deleteModal: (
+        <Modal
+          partials={{
+            title: translated.deleteComment,
+            description: translated.deleteCommentQuestion
+          }}
+          handleSubmit={() => this.props.onCommentDelete(this.props.index, this.props.parentIndex)}
+          action={translated.delete}
+          toggle={translated.delete}
+        />
+      ),
+      reportModal: (
+        <ReportModal
+          description={translated.reportTitle}
+          btnStyle="cta"
+          contentType={this.props.comment_content_type}
+        />
+      ),
+      urlModal: (
+        <UrlModal
+          title={translated.shareLink}
+          btnStyle="cta"
+          url={this.getCommentUrl()}
+        />
+      )
+    }
+
     return (
       <li>
         {this.props.displayNotification && <Alert type="success" message={translated.successMessage} />}
         <div className={(this.props.is_users_own_comment ? 'a4-comments__comment a4-comments__comment-owner' : 'a4-comments__comment')}>
           <a className="a4-comments__anchor" id={'comment_' + this.props.id} href={'./?comment=' + this.props.id}>{'Comment ' + this.props.id}</a>
-          {this.renderDeleteModal()}
           <div className="a4-comments__box">
             <div className="row">
               <div className={this.props.is_deleted ? 'd-none' : 'col-2 col-lg-1 a4-comments__user-img'}>
@@ -339,6 +345,7 @@ export default class Comment extends React.Component {
                     has_changing_permission={this.props.has_changing_permission}
                     has_deleting_permission={this.props.has_deleting_permission}
                     isParentComment={this.displayCategories()}
+                    modals={modals}
                   />}
               </div>
 
@@ -391,20 +398,9 @@ export default class Comment extends React.Component {
                       </a>
                     </button>}
 
-                  {!this.props.is_deleted &&
-                    <a
-                      className="btn btn--no-border a4-comments__action-bar__btn" href={'?comment_' + this.props.id}
-                      data-bs-toggle="modal" data-bs-target={'#share_comment_' + this.props.id}
-                    ><i className="fas fa-share" aria-hidden="true" /> {translated.share}
-                    </a>}
+                  {!this.props.is_deleted && modals.urlModal}
 
-                  {!this.props.is_deleted && this.props.authenticated_user_pk && !this.props.is_users_own_comment &&
-                    <a
-                      className="btn btn--no-border a4-comments__action-bar__btn" href={'#report_comment_' + this.props.id}
-                      data-bs-toggle="modal"
-                    ><i className="fas fa-exclamation-triangle" aria-hidden="true" />{translated.report}
-                    </a>}
-
+                  {!this.props.is_deleted && this.props.authenticated_user_pk && !this.props.is_users_own_comment && modals.reportModal}
                 </div>
               </div>
             </div>
@@ -465,20 +461,6 @@ export default class Comment extends React.Component {
               </div>)
             : null}
         </>
-        <ReportModal
-          name={'report_comment_' + this.props.id}
-          description={translated.reportTitle}
-          btnStyle="cta"
-          objectId={this.props.id}
-          contentType={this.props.comment_content_type}
-        />
-        <UrlModal
-          name={'share_comment_' + this.props.id}
-          title={translated.shareLink}
-          btnStyle="cta"
-          objectId={this.props.id}
-          url={this.getCommentUrl()}
-        />
       </li>
     )
   }

--- a/adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx
@@ -28,9 +28,7 @@ const CommentManageDropdown = (props) => {
         )}
         {props.has_deleting_permission && (
           <li className="dropdown-item">
-            <a href={'#comment_delete_' + props.id} data-bs-toggle="modal">
-              {translated.delete}
-            </a>
+            {props.modals.deleteModal}
           </li>
         )}
       </ul>

--- a/adhocracy4/comments_async/static/modals/UrlModal.jsx
+++ b/adhocracy4/comments_async/static/modals/UrlModal.jsx
@@ -1,49 +1,63 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import django from 'django'
 
 import Modal from '../../../static/Modal'
 
+const translated = {
+  share: django.gettext('Share'),
+  buttonTextCopy: django.gettext('Copy'),
+  buttonTextCopied: django.gettext('Copied')
+}
+
 export const UrlModal = (props) => {
   const [clicked, setClicked] = useState(false)
-  const buttonTextCopy = django.gettext('Copy')
-  const buttonTextCopied = django.gettext('Copied')
-  const partials = {}
-  partials.hideHeader = true
-  partials.hideFooter = true
-  partials.title = props.title
-  partials.body = (
-    <div className="input-group">
-      <input
-        id={'share-url-' + props.objectId}
-        type="text"
-        className="form-control"
-        value={props.url}
-        readOnly
-      />
-      <button
-        className="btn btn--primary input-group-append"
-        data-bs-toggle="button"
-        aria-pressed="false"
-        autoComplete="off"
-        onClick={(e) => copyUrl(e)}
-      >
-        {clicked ? buttonTextCopied : buttonTextCopy}
-      </button>
-    </div>
-  )
+  const inputRef = useRef(null)
 
-  const copyUrl = () => {
-    const copyText = document.getElementById('share-url-'.concat(props.objectId))
-    copyText.select()
-    document.execCommand('copy')
-    setClicked(true)
+  const copyUrl = (e) => {
+    e.preventDefault()
+    if (inputRef.current) {
+      navigator.clipboard.writeText(inputRef.current.value)
+        .then(() => {
+          setClicked(true)
+          return true
+        })
+        .catch((err) => {
+          console.error('Failed to copy text: ', err)
+        })
+    }
+  }
+
+  const partials = {
+    hideHeader: true,
+    hideFooter: true,
+    title: props.title,
+    body: (
+      <div className="input-group a4-url-modal__body">
+        <input
+          id={'share-url-' + props.objectId}
+          ref={inputRef}
+          type="text"
+          className="form-control"
+          value={props.url}
+          readOnly
+        />
+        <button
+          className="a4-url-modal__button"
+          aria-pressed={clicked}
+          autoComplete="off"
+          onClick={(e) => copyUrl(e)}
+        >
+          {clicked ? translated.buttonTextCopied : translated.buttonTextCopy}
+        </button>
+      </div>
+    )
   }
 
   return (
     <Modal
       abort={props.abort}
-      name={props.name}
       partials={partials}
+      toggle={<><i className="fas fa-share" aria-hidden="true" /> {translated.share}</>}
       keepOpenOnSubmit
     />
   )

--- a/adhocracy4/reports/static/reports/ReportModal.jsx
+++ b/adhocracy4/reports/static/reports/ReportModal.jsx
@@ -1,27 +1,41 @@
 import React, { useState } from 'react'
 import django from 'django'
-import Modal from '../../../static/Modal'
 import api from '../../../static/api'
+import Modal from '../../../static/Modal'
 
 const translations = {
+  reportTitle: django.gettext('Report Content'),
   reportSent: django.gettext('Report sent'),
   thankyouText: django.gettext('Thank you! We are taking care of it.'),
   placeholderText: django.gettext('Your message'),
-  sendReport: django.gettext('Send Report')
+  sendReport: django.gettext('Send Report'),
+  report: django.gettext('Report'),
+  validationError: django.gettext('Please enter a message before submitting.')
 }
 
 export const ReportModal = (props) => {
   const [report, setReport] = useState('')
   const [showSuccessMessage, setShowSuccessMessage] = useState(false)
   const [showReportForm, setShowReportForm] = useState(true)
+  const [validationError, setValidationError] = useState(false)
 
   const partials = {}
 
   const handleTextChange = (e) => {
     setReport(e.target.value)
+    // Clear validation error when user starts typing
+    if (validationError) {
+      setValidationError(false)
+    }
   }
 
   const submitReport = () => {
+    // Validate before submitting
+    if (!report.trim()) {
+      setValidationError(true)
+      return
+    }
+
     api.report.submit({
       description: report,
       content_type: props.contentType,
@@ -31,6 +45,7 @@ export const ReportModal = (props) => {
         setReport('')
         setShowSuccessMessage(true)
         setShowReportForm(false)
+        setValidationError(false)
       })
   }
 
@@ -44,26 +59,33 @@ export const ReportModal = (props) => {
     partials.hideFooter = true
     partials.bodyClass = 'success'
   } else if (showReportForm) {
-    partials.title = translations.sendReport
+    partials.title = translations.reportTitle
     partials.description = props.description
     partials.body = (
       <div className="form-group">
         <textarea
-          rows="5" className="form-control report-message" value={report}
-          placeholder={translations.placeholderText} onChange={handleTextChange}
+          rows="5"
+          className={'form-control report-message' + (validationError ? ' is-invalid' : '')}
+          value={report}
+          placeholder={translations.placeholderText}
+          onChange={handleTextChange}
         />
+        {validationError && (
+          <div className="message message--error">
+            {translations.validationError}
+          </div>
+        )}
       </div>
     )
   }
 
   return (
     <Modal
-      abort={props.abort}
-      name={props.name}
+      partials={partials}
       handleSubmit={submitReport}
       action={translations.sendReport}
-      partials={partials}
       keepOpenOnSubmit
+      toggle={<><i className="fas fa-exclamation-triangle" aria-hidden="true" /> {translations.report}</>}
     />
   )
 }

--- a/adhocracy4/reports/static/reports/react_reports.jsx
+++ b/adhocracy4/reports/static/reports/react_reports.jsx
@@ -8,19 +8,12 @@ module.exports.ReportModal = ReportModal
 
 module.exports.renderReports = function (el) {
   const props = JSON.parse(el.getAttribute('data-attributes'))
+  const root = createRoot(el)
 
-  el.setAttribute('href', '#' + props.modalName)
-  el.setAttribute('data-bs-toggle', 'modal')
-
-  const container = document.createElement('div')
-  document.body.appendChild(container)
-
-  const root = createRoot(container)
   root.render(
     <ReportModal
       name={props.modalName}
-      description={django.gettext('You want to report this content? Your message will be sent to the moderation. The moderation will look at the reported content. The content will be deleted if it does not meet our discussion rules (netiquette).')}
-      btnStyle="cta"
+      description={django.gettext('Do you want to report this content? Your message will be sent to our moderation team. They will review the reported content, and if it violates our discussion rules (netiquette), it will be removed.')}
       objectId={props.objectId}
       contentType={props.contentType}
     />)

--- a/adhocracy4/reports/templatetags/react_reports.py
+++ b/adhocracy4/reports/templatetags/react_reports.py
@@ -32,8 +32,8 @@ def react_reports(obj, text=None, **kwargs):
 
     return format_html(
         (
-            '<a href="#{modal_name}" data-a4-widget="reports"'
-            ' data-attributes="{attributes}" class="{class_names}">{text}</a>'
+            '<span id="{modal_name}" data-a4-widget="reports"'
+            ' data-attributes="{attributes}" class="{class_names}">{text}</span>'
         ),
         attributes=json.dumps(attributes),
         modal_name=modal_name,

--- a/changelog/_0003.md
+++ b/changelog/_0003.md
@@ -1,0 +1,13 @@
+### Changed
+- Refactored static/Modal.jsx
+- Replaced Bootstrap modals with native HTML `<dialog>`
+- Migrated from Bootstrap classes to custom CSS classes
+- Modified `react_reports.py` to adapt data passing pattern for new modal structure
+
+### Added
+- Mobile-specific modal styling with bottom sheet animation
+- New CSS classes following `a4-modal` prefix convention
+- Input validation and error handling for ReportModal.jsx
+
+### Removed
+- Removed Bootstrap modal dependencies

--- a/tests/reports/test_report_templatetags.py
+++ b/tests/reports/test_report_templatetags.py
@@ -21,9 +21,9 @@ def react_reports_render_template(template, rf, question):
     modal_name = "{mountpoint}_modal".format(mountpoint=mountpoint)
 
     expected = (
-        r"^<a href=\"#{modal_name}\" data-a4-widget=\"reports\""
+        r"^<span id=\"{modal_name}\" data-a4-widget=\"reports\""
         r" data-attributes=\"(?P<props>{{.+}})\""
-        r" class=\"(?P<class_names>.*)\">(?P<text>.+)</a>$"
+        r" class=\"(?P<class_names>.*)\">(?P<text>.+)</span>$"
     ).format(modal_name=modal_name)
 
     match = re.match(expected, helpers.render_template(template, context))


### PR DESCRIPTION
**_please dont merge this once approved, waiting to touch a-plus first_**

Replace Bootstrap modals with native HTML <dialog> element  and update styles for the mB redesign.

This change simplifies our modal implementation while improving the mobile experience. The <dialog> element provides better accessibility and native support for modal behaviors.

https://github.com/user-attachments/assets/3fb8d9a0-9e58-4510-b780-dc92d0c98ef7

https://github.com/user-attachments/assets/0215e666-2eab-40f6-9323-e0f9f697e734


TODO:
- [ ] a-plus dependency