### PR TITLE
[#8639] address-search: move components into a4 from mein_berlin PT 1

### DIFF
--- a/adhocracy4/maps_react/static/a4maps_react/AddressSearch.jsx
+++ b/adhocracy4/maps_react/static/a4maps_react/AddressSearch.jsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react'
+import django from 'django'
+import { useMap } from 'react-leaflet'
+import L from 'leaflet'
+
+import useDebounce from '../../../static/useDebounce'
+import { AutoComplete } from '../../../static/forms/AutoComplete'
+import { makeIcon } from './GeoJsonMarker'
+
+const addressSearchCapStr = django.gettext('Address Search')
+let activeMarker = null
+
+function fetchSuggestions (address) {
+  return fetch(apiUrl + '?address=' + address)
+    .then((response) => response.json())
+}
+
+function getSearchResultText (feature) {
+  return feature.properties.strname + ' ' + feature.properties.hsnr + ' in ' + feature.properties.plz + ' ' + feature.properties.bezirk_name
+}
+
+const apiUrl = 'https://bplan-prod.liqd.net/api/addresses/'
+
+const AddressSearch = ({
+  onSubmitHandler
+}) => {
+  const [geoJson, setGeoJson] = useState(null)
+  const [searchString, setSearchString] = useState('')
+  const map = useMap()
+
+  const debouncedOnChange = useDebounce(async () => {
+    const geoJson = await fetchSuggestions(searchString)
+    setGeoJson(geoJson)
+  })
+
+  const onAddressSelect = (val) => {
+    let leafletMarker
+    if (activeMarker) {
+      map.removeLayer(activeMarker)
+    }
+    const feature = geoJson.features[val[0]]
+    activeMarker = L.geoJSON(feature, {
+      pointToLayer: function (feature, latlng) {
+        leafletMarker = L.marker(latlng, {
+          icon: makeIcon('/static/images/map_pin_active.svg'),
+          alt: 'Marker: ' + getSearchResultText(feature)
+        })
+        return leafletMarker
+      }
+    }).addTo(map)
+    leafletMarker.getElement()?.focus()
+
+    map.flyToBounds(activeMarker.getBounds(), { maxZoom: 13 })
+  }
+
+  useEffect(() => {
+    debouncedOnChange()
+  }, [searchString])
+
+  return (
+    <div className="a4-address-search">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          onSubmitHandler(e)
+        }}
+        data-embed-target="ignore"
+      >
+        <div className="a4-address-search__search-form">
+          <div className="form-group">
+            <AutoComplete
+              choices={geoJson
+                ? geoJson.features.map((feature, index) => ({
+                  name: getSearchResultText(feature),
+                  value: index
+                }))
+                : []}
+              // filtering is happening on the server
+              filterFn={() => true}
+              hideLabel
+              label={addressSearchCapStr}
+              placeholder={addressSearchCapStr}
+              onChangeInput={(val) => {
+                setSearchString(val)
+
+                if (val === '' && activeMarker) {
+                  map.removeLayer(activeMarker)
+                  activeMarker = null
+                }
+              }}
+              onChange={onAddressSelect}
+              inputValue={searchString}
+              before={
+                <i className="fa fa-search" aria-hidden="true" />
+              }
+            />
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default AddressSearch

--- a/adhocracy4/maps_react/static/a4maps_react/ControlWrapper.js
+++ b/adhocracy4/maps_react/static/a4maps_react/ControlWrapper.js
@@ -1,0 +1,64 @@
+import { useState, forwardRef, useEffect, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+import { createElementHook, createControlHook } from '@react-leaflet/core'
+import { Control, DomUtil, DomEvent } from 'leaflet'
+
+const ControlWrapper = Control.extend({
+  options: {
+    className: '',
+    onOff: '',
+    handleOff: () => undefined
+  },
+
+  onAdd () {
+    const _controlDiv = DomUtil.create('div', this.options.className)
+    DomEvent.disableClickPropagation(_controlDiv)
+    DomEvent.disableScrollPropagation(_controlDiv)
+    return _controlDiv
+  },
+
+  onRemove (map) {
+    if (this.options.onOff) {
+      map.off(this.options.onOff, this.options.handleOff, this)
+    }
+
+    return this
+  }
+})
+
+const createControl = (props, context) => {
+  const instance = new ControlWrapper(props)
+  return { instance, context: { ...context, overlayContainer: instance } }
+}
+
+const useControlElement = createElementHook(createControl)
+const useControl = createControlHook(useControlElement)
+
+const useForceUpdate = () => {
+  // eslint-disable-next-line no-unused-vars
+  const [_, setValue] = useState(0) // integer state
+  return useCallback(() => setValue((value) => value + 1), []) // update the state to force render
+}
+
+const createLeafletControl = (useElement) => {
+  const Component = (props, _ref) => {
+    const forceUpdate = useForceUpdate()
+    const { instance } = useElement(props).current
+
+    useEffect(() => {
+      // Origin: https://github.com/LiveBy/react-leaflet-control/blob/master/lib/control.jsx
+      // This is needed because the control is only attached to the map in
+      // MapControl's componentDidMount, so the container is not available
+      // until this is called. We need to now force a render so that the
+      // portal and children are actually rendered.
+      forceUpdate()
+    }, [forceUpdate])
+
+    const contentNode = instance.getContainer()
+    // eslint-disable-next-line react/prop-types
+    return contentNode ? createPortal(props.children, contentNode) : null
+  }
+  return forwardRef(Component)
+}
+
+export default createLeafletControl(useControl)

--- a/adhocracy4/static/classNames.js
+++ b/adhocracy4/static/classNames.js
@@ -1,0 +1,12 @@
+/*
+ * creates a string for className attribute from an array of classnames
+ * while filtering out empty strings and undefined
+ *
+ * @param {...string} classes
+ * @returns {string}
+ */
+const classNames = (...classes) => {
+  return classes.filter(Boolean).join(' ')
+}
+
+export default classNames

--- a/adhocracy4/static/forms/AutoComplete.jsx
+++ b/adhocracy4/static/forms/AutoComplete.jsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react'
+import classNames from '../../static/classNames'
+import useCombobox from './useCombobox'
+
+/*
+ * Returns the item at the given index in an array, wrapping around
+ * if index is out of bounds.
+ */
+export const getLoopedIndex = (array, index) => {
+  const length = array.length
+  const wrappedIndex = ((index % length) + length) % length
+  return array[wrappedIndex]
+}
+
+const defaultFilterFn = (choice, text) => choice.name.toLowerCase().includes(text.toLowerCase())
+
+/*
+  Choice formatting looks like:
+  { name: 'Swedish', value: 'sv' },
+  { name: 'English', value: 'en' }
+  Values need to be unique!
+ */
+export const AutoComplete = ({
+  label,
+  className,
+  liClassName,
+  comboboxClassName,
+  choices,
+  hideLabel,
+  onChangeInput,
+  filterFn,
+  placeholder,
+  before,
+  after,
+  ...comboboxProps
+}) => {
+  const {
+    opened,
+    labelId,
+    activeItems,
+    listboxAttrs,
+    comboboxAttrs,
+    getChoicesAttr
+  } = useCombobox({
+    choices,
+    ...comboboxProps,
+    isAutoComplete: true
+  })
+  const [text, setText] = useState('')
+
+  const classes = classNames(
+    'form-control a4-combo-box__container',
+    opened && 'a4-combo-box__container--opened',
+    className
+  )
+  const comboboxClasses = classNames(
+    'form-control a4-combo-box__combobox',
+    comboboxClassName
+  )
+
+  const actualFilterFn = filterFn || defaultFilterFn
+  const filteredChoices = text !== '' ? choices.filter(choice => actualFilterFn(choice, text)) : choices
+
+  const onChangeHandler = (e) => {
+    setText(e.target.value)
+    onChangeInput?.(e.target.value)
+  }
+
+  return (
+    <div className="form-group a4-combo-box a4-combo-box--autocomplete">
+      <p id={labelId} className={classNames('label', hideLabel && 'aural')}>
+        {label}
+      </p>
+      <div className="a4-combo-box__input-wrapper form-control">
+        {before && <div className="a4-combo-box__before">{before}</div>}
+        {comboboxProps.isMultiple && (
+          <div className="a4-combo-box__selected">
+            {activeItems.map((choice) => choice.name).join(', ')}
+          </div>
+        )}
+        <input
+          type="text"
+          value={text}
+          onChange={onChangeHandler}
+          placeholder={placeholder}
+          className={comboboxClasses}
+          {...comboboxAttrs}
+        />
+        {after && <div className="a4-combo-box__after">{after}</div>}
+      </div>
+      {filteredChoices.length > 0 && (
+        <ul className={classes} {...listboxAttrs}>
+          {
+          filteredChoices.map((choice) => {
+            const { active, focused, ...attrs } = getChoicesAttr(choice)
+            const liClasses = classNames(
+              liClassName,
+              'a4-combo-box__option',
+              active && 'a4-combo-box__option--active',
+              focused && 'a4-combo-box__option--focus'
+            )
+
+            return (
+              // No keyboard event is needed here. Keyboard management happens
+              // in the combobox element, where the focus is kept at all times.
+              // see https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
+              // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+              <li
+                key={choice.value}
+                className={liClasses}
+                {...attrs}
+              >
+                <span>{choice.name}</span>
+                {active && <i className="fa fa-check" aria-hidden="true" />}
+              </li>
+            )
+          })
+        }
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/adhocracy4/static/forms/__tests__/AutoComplete.jest.jsx
+++ b/adhocracy4/static/forms/__tests__/AutoComplete.jest.jsx
@@ -1,0 +1,218 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AutoComplete } from '../AutoComplete'
+import useCombobox from '../useCombobox'
+
+jest.mock('../useCombobox')
+
+describe('AutoComplete', () => {
+  const choices = [
+    { name: 'Swedish', value: 'sv' },
+    { name: 'English', value: 'en' },
+    { name: 'German', value: 'de' }
+  ]
+
+  const defaultMockHookReturn = {
+    opened: false,
+    labelId: 'test-label-id',
+    activeItems: [],
+    listboxAttrs: {
+      role: 'listbox',
+      'aria-multiselectable': 'true'
+    },
+    comboboxAttrs: {
+      role: 'combobox',
+      'aria-haspopup': 'true',
+      'aria-expanded': false,
+      'aria-labelledby': 'test-label-id'
+    },
+    getChoicesAttr: (choice) => ({
+      role: 'option',
+      'aria-selected': false,
+      active: false,
+      focused: false
+    })
+  }
+
+  beforeEach(() => {
+    useCombobox.mockImplementation(() => defaultMockHookReturn)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('renders with label and input', () => {
+    render(
+      <AutoComplete
+        label="Search Languages"
+        choices={choices}
+        placeholder="Type to search"
+      />
+    )
+
+    expect(screen.getByText('Search Languages')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Type to search')).toBeInTheDocument()
+  })
+
+  test('handles text input and filtering', () => {
+    const onChangeInput = jest.fn()
+    render(
+      <AutoComplete
+        label="Search Languages"
+        choices={choices}
+        onChangeInput={onChangeInput}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'en' } })
+
+    expect(input.value).toBe('en')
+    expect(onChangeInput).toHaveBeenCalledWith('en')
+    expect(screen.getByText('English')).toBeInTheDocument()
+    expect(screen.queryByText('Swedish')).not.toBeInTheDocument()
+  })
+
+  test('applies custom filter function', () => {
+    const customFilter = jest.fn((choice, text) => choice.value.includes(text))
+    render(
+      <AutoComplete
+        label="Search Languages"
+        choices={choices}
+        filterFn={customFilter}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'sv' } })
+
+    expect(customFilter).toHaveBeenCalled()
+  })
+
+  test('hides label when hideLabel is true', () => {
+    render(
+      <AutoComplete
+        label="Search Languages"
+        choices={choices}
+        hideLabel
+      />
+    )
+
+    const label = screen.getByText('Search Languages')
+    expect(label).toHaveClass('aural')
+  })
+
+  test('renders before and after elements', () => {
+    render(
+      <AutoComplete
+        label="Search Languages"
+        choices={choices}
+        before={<div data-testid="before">Before</div>}
+        after={<div data-testid="after">After</div>}
+      />
+    )
+
+    expect(screen.getByTestId('before')).toBeInTheDocument()
+    expect(screen.getByTestId('after')).toBeInTheDocument()
+  })
+
+  test('displays multiple selected items', () => {
+    useCombobox.mockImplementation(() => ({
+      ...defaultMockHookReturn,
+      activeItems: [
+        { name: 'English', value: 'en' },
+        { name: 'German', value: 'de' }
+      ]
+    }))
+
+    render(
+      <AutoComplete
+        label="Search Languages"
+        choices={choices}
+        isMultiple
+      />
+    )
+
+    expect(screen.getByText('English, German')).toBeInTheDocument()
+  })
+
+  test('applies custom class names', () => {
+    render(
+      <AutoComplete
+        label="Search Languages"
+        choices={choices}
+        className="custom-class"
+        comboboxClassName="custom-combobox"
+        liClassName="custom-li"
+      />
+    )
+
+    expect(screen.getByRole('listbox')).toHaveClass('custom-class')
+    expect(screen.getByRole('combobox')).toHaveClass('custom-combobox')
+    const options = screen.getAllByRole('option')
+    options.forEach(option => {
+      expect(option).toHaveClass('custom-li')
+    })
+  })
+
+  test('shows check icon for active items', () => {
+    useCombobox.mockImplementation(() => ({
+      ...defaultMockHookReturn,
+      getChoicesAttr: (choice) => ({
+        ...defaultMockHookReturn.getChoicesAttr(choice),
+        active: choice.value === 'en'
+      })
+    }))
+
+    render(
+      <AutoComplete
+        label="Search Languages"
+        choices={choices}
+      />
+    )
+
+    const checkIcon = screen.getByText('English').closest('li').querySelector('.bicon-check')
+    expect(checkIcon).toBeInTheDocument()
+  })
+
+  test('hides listbox when no filtered choices', () => {
+    render(
+      <AutoComplete
+        label="Search Languages"
+        choices={choices}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'xyz' } })
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  test('passes isAutoComplete prop to useCombobox', () => {
+    render(
+      <AutoComplete
+        label="Search Languages"
+        choices={choices}
+      />
+    )
+
+    expect(useCombobox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isAutoComplete: true
+      })
+    )
+  })
+
+  test('handles empty choices array', () => {
+    render(
+      <AutoComplete
+        label="Search Languages"
+        choices={[]}
+      />
+    )
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+})

--- a/adhocracy4/static/forms/__tests__/useCombobox.jest.js
+++ b/adhocracy4/static/forms/__tests__/useCombobox.jest.js
@@ -1,0 +1,233 @@
+import { renderHook, act } from '@testing-library/react'
+import useCombobox from '../useCombobox'
+
+const mockChoices = [
+  { value: '1', name: 'Option 1' },
+  { value: '2', name: 'Option 2' },
+  { value: '3', name: 'Option 3' }
+]
+
+const defaultProps = {
+  choices: mockChoices,
+  values: undefined,
+  defaultValue: [],
+  onChange: jest.fn(),
+  isAutoComplete: false,
+  isMultiple: false,
+  search: ''
+}
+
+describe('useCombobox', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('initializes with default values', () => {
+    const { result } = renderHook(() => useCombobox(defaultProps))
+
+    expect(result.current.opened).toBe(false)
+    expect(result.current.activeItems).toEqual([])
+    expect(result.current.labelId).toBeTruthy()
+    expect(result.current.comboboxAttrs['aria-expanded']).toBe(false)
+  })
+
+  test('toggles dropdown on click', () => {
+    const { result } = renderHook(() => useCombobox(defaultProps))
+
+    act(() => {
+      result.current.comboboxAttrs.onClick()
+    })
+
+    expect(result.current.opened).toBe(true)
+    expect(result.current.comboboxAttrs['aria-expanded']).toBe(true)
+  })
+
+  test('handles keyboard navigation', () => {
+    const { result } = renderHook(() => useCombobox(defaultProps))
+
+    act(() => {
+      result.current.comboboxAttrs.onClick()
+    })
+    expect(result.current.comboboxAttrs['aria-activedescendant']).toBe('1')
+
+    act(() => {
+      result.current.comboboxAttrs.onKeyDown({ key: 'ArrowDown', preventDefault: jest.fn() })
+    })
+    expect(result.current.comboboxAttrs['aria-activedescendant']).toBe('2')
+
+    act(() => {
+      result.current.comboboxAttrs.onKeyDown({ key: 'ArrowDown', preventDefault: jest.fn() })
+    })
+    expect(result.current.comboboxAttrs['aria-activedescendant']).toBe('3')
+
+    act(() => {
+      result.current.comboboxAttrs.onKeyDown({ key: 'ArrowUp', preventDefault: jest.fn() })
+    })
+    expect(result.current.comboboxAttrs['aria-activedescendant']).toBe('2')
+  })
+
+  test('handles multiple selection', () => {
+    const multipleProps = {
+      ...defaultProps,
+      isMultiple: true
+    }
+
+    const { result } = renderHook(() => useCombobox(multipleProps))
+
+    // Select first option
+    act(() => {
+      const choiceAttrs = result.current.getChoicesAttr(mockChoices[0])
+      choiceAttrs.onClick()
+    })
+
+    expect(result.current.activeItems).toHaveLength(1)
+    expect(result.current.activeItems[0]).toEqual(mockChoices[0])
+
+    // Select second option
+    act(() => {
+      const choiceAttrs = result.current.getChoicesAttr(mockChoices[1])
+      choiceAttrs.onClick()
+    })
+
+    expect(result.current.activeItems).toHaveLength(2)
+    expect(result.current.activeItems).toEqual([mockChoices[0], mockChoices[1]])
+  })
+
+  test('handles single selection', () => {
+    const { result } = renderHook(() => useCombobox(defaultProps))
+
+    // Select first option
+    act(() => {
+      const choiceAttrs = result.current.getChoicesAttr(mockChoices[0])
+      choiceAttrs.onClick()
+    })
+
+    expect(result.current.activeItems).toHaveLength(1)
+    expect(result.current.activeItems[0]).toBe(mockChoices[0])
+
+    // Select second option (should replace first)
+    act(() => {
+      const choiceAttrs = result.current.getChoicesAttr(mockChoices[1])
+      choiceAttrs.onClick()
+    })
+
+    expect(result.current.activeItems).toHaveLength(1)
+    expect(result.current.activeItems[0]).toBe(mockChoices[1])
+  })
+
+  test('closes on escape key', () => {
+    const { result } = renderHook(() => useCombobox(defaultProps))
+
+    // Open dropdown
+    act(() => {
+      result.current.comboboxAttrs.onClick()
+    })
+
+    expect(result.current.opened).toBe(true)
+
+    // Press escape
+    act(() => {
+      result.current.comboboxAttrs.onKeyDown({ key: 'Escape' })
+    })
+
+    expect(result.current.opened).toBe(false)
+  })
+
+  test('handles controlled values', () => {
+    const controlledProps = {
+      ...defaultProps,
+      values: ['1']
+    }
+
+    const { result } = renderHook(() => useCombobox(controlledProps))
+
+    expect(result.current.activeItems).toHaveLength(1)
+    expect(result.current.activeItems[0]).toBe(mockChoices[0])
+  })
+
+  test('handles type-to-select', () => {
+    const { result } = renderHook(() => useCombobox(defaultProps))
+
+    act(() => {
+      result.current.comboboxAttrs.onKeyDown({ key: 'O', length: 1 })
+    })
+
+    expect(result.current.comboboxAttrs['aria-activedescendant']).toBe('1')
+  })
+
+  test('handles Home and End keys', () => {
+    const { result } = renderHook(() => useCombobox(defaultProps))
+
+    act(() => {
+      result.current.comboboxAttrs.onKeyDown({ key: 'End', preventDefault: jest.fn() })
+    })
+    expect(result.current.comboboxAttrs['aria-activedescendant']).toBe('3')
+
+    act(() => {
+      result.current.comboboxAttrs.onKeyDown({ key: 'Home', preventDefault: jest.fn() })
+    })
+    expect(result.current.comboboxAttrs['aria-activedescendant']).toBe('1')
+  })
+
+  test('calls onChange when selection changes', () => {
+    const onChange = jest.fn()
+    const propsWithOnChange = {
+      ...defaultProps,
+      onChange
+    }
+
+    const { result } = renderHook(() => useCombobox(propsWithOnChange))
+
+    act(() => {
+      const choiceAttrs = result.current.getChoicesAttr(mockChoices[0])
+      choiceAttrs.onClick()
+    })
+
+    expect(onChange).toHaveBeenCalledWith(['1'])
+  })
+})
+
+describe('useCombobox accessibility', () => {
+  test('provides correct ARIA attributes', () => {
+    const { result } = renderHook(() => useCombobox(defaultProps))
+
+    expect(result.current.comboboxAttrs['aria-haspopup']).toBe('true')
+    expect(result.current.listboxAttrs['aria-multiselectable']).toBe('true')
+    expect(result.current.listboxAttrs.role).toBe('listbox')
+    expect(result.current.comboboxAttrs.role).toBe('combobox')
+  })
+
+  test('handles focus management correctly', () => {
+    const { result } = renderHook(() => useCombobox(defaultProps))
+    const mockEvent = {
+      relatedTarget: null
+    }
+
+    act(() => {
+      result.current.comboboxAttrs.onBlur(mockEvent)
+    })
+
+    expect(result.current.opened).toBe(false)
+  })
+})
+
+describe('useCombobox with autoComplete', () => {
+  test('handles space key differently in autoComplete mode', () => {
+    const autoCompleteProps = {
+      ...defaultProps,
+      isAutoComplete: true
+    }
+
+    const { result } = renderHook(() => useCombobox(autoCompleteProps))
+
+    act(() => {
+      result.current.comboboxAttrs.onKeyDown({
+        key: ' ',
+        preventDefault: jest.fn()
+      })
+    })
+
+    // Space should not trigger option selection in autoComplete mode
+    expect(result.current.opened).toBe(false)
+  })
+})

--- a/adhocracy4/static/forms/useCombobox.js
+++ b/adhocracy4/static/forms/useCombobox.js
@@ -1,0 +1,204 @@
+import { useCallback, useId, useMemo, useRef, useState } from 'react'
+import { getLoopedIndex } from './AutoComplete'
+
+function getTargets (choices, focusedIndex) {
+  return {
+    first: choices[0],
+    last: choices[choices.length - 1],
+    next: typeof focusedIndex === 'number' ? getLoopedIndex(choices, focusedIndex + 1) : null,
+    prev: typeof focusedIndex === 'number' ? getLoopedIndex(choices, focusedIndex - 1) : null
+  }
+}
+
+function toggleValue (value, values) {
+  const shouldRemove = values.includes(value)
+  let newValues = [...values, value]
+  if (shouldRemove) {
+    newValues = values.filter(item => item !== value)
+  }
+  return newValues
+}
+
+/**
+ * A custom hook that provides accessibility and keyboard/event handling for combobox-like components.
+ * This means it can be used for any select-like ui element. So, an autocomplete, a multiselect, etc.
+ * Implements the WAI-ARIA Combobox Pattern (https://www.w3.org/WAI/ARIA/apg/patterns/combobox/).
+ *
+ * @param {Object} props - The configuration options for the combobox
+ * @param {Array<{name: string, value: any}>} props.choices - Array of choice objects with name and value properties
+ * @param {Array<any>} [props.values] - Array of selected values (for controlled components)
+ * @param {any|Array<any>} [props.defaultValue] - Default selected value(s) (for uncontrolled components)
+ * @param {Function} [props.onChange] - Callback function called when selection changes: (newValues: Array<any>) => void
+ * @param {boolean} [props.isAutoComplete] - Whether the combobox is used for autocompletion
+ * @param {boolean} [props.isMultiple] - Whether multiple values can be selected
+ * @param {string} [props.search] - Search string for filtering choices
+ *
+ * @returns {Object} An object containing:
+ * .comboboxAttrs - Props to spread on the combobox element including ARIA attributes
+ * .listboxAttrs - Props to spread on the listbox element including ARIA attributes
+ * .labelId - Generated ID for the label element
+ * .activeItems - Currently selected items
+ * .getChoicesAttr - Function to get props for individual choice elements
+ * .opened - Whether the listbox is currently open
+ *
+ * @example
+ * see adhocracy4/static/forms/AutoComplete.jsx
+ */
+const useCombobox = ({
+  choices,
+  values,
+  defaultValue,
+  onChange,
+  isAutoComplete,
+  isMultiple,
+  search
+}) => {
+  const defaultValueArray = Array.isArray(defaultValue) ? defaultValue : [defaultValue]
+
+  const listboxRef = useRef(null)
+  const comboboxRef = useRef(null)
+  const typed = useRef('')
+
+  const [internalValue, setInternalValue] = useState(defaultValueArray)
+  const [focused, setFocused] = useState(null)
+  const [opened, setOpened] = useState(false)
+
+  const containerId = useId()
+  const labelId = useId()
+
+  // Use values prop if provided (controlled), otherwise use internal state (uncontrolled)
+  const active = useMemo(() => values ?? internalValue, [values, internalValue])
+
+  const activeItems = choices.filter(choice => active.includes(choice.value))
+  const focusedItem = choices.find((choice) => choice.value === focused)
+  const focusedIndex = choices.findIndex(choice => choice.value === focused)
+  const targets = getTargets(choices, focusedIndex)
+
+  const toggleOption = useCallback((v) => {
+    const newValues = isMultiple ? toggleValue(v, active) : [v]
+    if (values === undefined) setInternalValue(newValues)
+    if (onChange) onChange(newValues)
+    if (!isMultiple) setOpened(false)
+  }, [values, onChange, active])
+
+  const onClick = useCallback(() => {
+    if (!opened && targets.first) {
+      setFocused(targets.first.value)
+    }
+    setOpened(!opened)
+  }, [opened])
+
+  const onBlur = useCallback((e) => {
+    if (listboxRef.current?.contains(e.relatedTarget)) {
+      setTimeout(() => comboboxRef.current?.focus(), 10)
+      return
+    }
+    setOpened(false)
+  }, [listboxRef])
+
+  const getChoicesAttr = (choice) => ({
+    active: active.includes(choice.value),
+    focused: focusedItem?.value === choice.value,
+    role: 'option',
+    'aria-selected': active.includes(choice.value),
+    onClick: () => {
+      toggleOption(choice.value)
+      setFocused(choice.value)
+    },
+    ref: focusedItem?.value === choice.value ? (node) => node?.scrollIntoView({ block: 'nearest' }) : null,
+    tabIndex: -1
+  })
+
+  const onKeyDown = useCallback((e) => {
+    const key = e.key
+    switch (key) {
+      case ' ':
+        if (isAutoComplete) return
+        e.preventDefault()
+        if (!opened && targets.first) {
+          setFocused(targets.first.value)
+          setOpened(true)
+        } else if (focused) {
+          toggleOption(focused)
+        } else {
+          return
+        }
+        break
+      case 'Enter':
+        e.preventDefault()
+
+        if (opened && focused) {
+          toggleOption(focused)
+        } else if (!opened) {
+          setFocused(targets.first.value)
+        }
+        setOpened(!opened)
+        break
+      case 'Escape':
+        setOpened(false)
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        if (targets.prev) {
+          setFocused(targets.prev.value)
+        }
+        break
+      case 'ArrowDown':
+        e.preventDefault()
+        if (targets.next) {
+          setFocused(targets.next.value)
+        }
+        if (!opened) {
+          if (targets.first) {
+            setFocused(targets.first.value)
+          }
+          setOpened(true)
+        }
+        break
+      case 'Home':
+        e.preventDefault()
+        setFocused(targets.first.value)
+        break
+      case 'End':
+        e.preventDefault()
+        setFocused(targets.last.value)
+        break
+    }
+    if (key.length === 1 && !isAutoComplete) {
+      typed.current += key
+      const filtered = choices.filter(choice => choice.name.toLowerCase().startsWith(typed.current.toLowerCase()))
+      if (filtered.length) {
+        setFocused(filtered[0].value)
+      }
+      setTimeout(() => { typed.current = '' }, 200)
+    }
+  }, [focused, opened, targets, choices, isAutoComplete])
+
+  return {
+    comboboxAttrs: {
+      onClick,
+      onBlur,
+      onKeyDown,
+      tabIndex: 0,
+      'aria-haspopup': 'true',
+      'aria-expanded': opened,
+      'aria-activedescendant': focusedItem?.value,
+      'aria-labelledby': labelId,
+      'aria-controls': containerId,
+      role: 'combobox',
+      ref: comboboxRef
+    },
+    listboxAttrs: {
+      role: 'listbox',
+      'aria-multiselectable': 'true',
+      ref: listboxRef,
+      id: containerId
+    },
+    labelId,
+    activeItems,
+    getChoicesAttr,
+    opened
+  }
+}
+
+export default useCombobox

--- a/adhocracy4/static/useDebounce.js
+++ b/adhocracy4/static/useDebounce.js
@@ -1,0 +1,32 @@
+import { useEffect, useMemo, useRef } from 'react'
+import debounce from 'lodash.debounce'
+
+/**
+ * A custom hook that returns a debounced callback function. A debounced function
+ * means that it will wait for a certain amount of time before executing the
+ * original function. So it will make sure that for certain events like typing
+ * in an input field, the function is not executed too often.
+ *
+ * @param {function} callback - The callback function to be debounced.
+ * @param {number} delay - The delay in milliseconds.
+ * @returns {function} - The debounced callback function.
+ */
+const useDebounce = (callback, delay = 1000) => {
+  const ref = useRef()
+
+  useEffect(() => {
+    ref.current = callback
+  }, [callback])
+
+  const debouncedCallback = useMemo(() => {
+    const func = () => {
+      ref.current?.()
+    }
+
+    return debounce(func, delay)
+  }, [delay])
+
+  return debouncedCallback
+}
+
+export default useDebounce

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ import './adhocracy4/static/global_jquery'
 
 export { default as alert } from './adhocracy4/static/Alert'
 export { default as api } from './adhocracy4/static/api'
+export { default as classNames } from './adhocracy4/static/classNames'
+export { default as AddressSearch } from './adhocracy4/maps_react/static/a4maps_react/AddressSearch'
 export { default as comments } from './adhocracy4/comments/static/comments/react_comments'
 export * as commentsAsync from './adhocracy4/comments_async/static/comments_async/react_comments_async'
 export { default as config } from './adhocracy4/static/config'


### PR DESCRIPTION
This is part 1 of 2. Please feel already free to review and merge this. This will be merged into another branch that stems from `main` and so will part 2. Doing it like this allows me to split this story up for easier review into...

1. Moving components around (from mb -> a4)
2. Making further code changes in these components to fulfil the user story.

Once both parts are reviewed & merged into this branch `pv-2025-01-address-search` I can then merge this into `dev` (mb)/`main` (a4)

**Describe your changes**
Moves components out of mein berlin and into a4, adapts code to be more generic. It moves over:

1. The useCombobox hook, that is used in a) AutoComplete (AddressSearch) and b) Multi-Select
2. the useDebounce hook which is used to create debounced callbacks that you can put on e.g. a onChange handler and then it waits x milliseconds before triggering the actual callback and if another change event happens it resets the timer.
4. The ProjectsMapSearch component (now called AddressSearch) – the main part of this story
5. The AutoComplete component – which the AddressSearch is built on top of.

meinberlin PR: https://github.com/liqd/a4-meinberlin/pull/5969

**Tasks**
- [x] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
