### PR TITLE
maps/react: fix react map namespaces

### DIFF
--- a/adhocracy4/maps_react/templatetags/react_maps_tags.py
+++ b/adhocracy4/maps_react/templatetags/react_maps_tags.py
@@ -15,6 +15,7 @@ def react_choose_point(polygon, point, name):
     }
 
     return format_html(
-        '<div data-a4-widget="choose-point" ' 'data-attributes="{attributes}"></div>',
+        '<div data-a4-widget="react-choose-point" '
+        'data-attributes="{attributes}"></div>',
         attributes=json.dumps(attributes),
     )

--- a/adhocracy4/maps_react/widgets.py
+++ b/adhocracy4/maps_react/widgets.py
@@ -10,14 +10,14 @@ class MapChoosePointWidget(Widget):
         super().__init__(attrs)
 
     class Media:
-        js = ("a4maps_choose_point.js",)
+        js = ("a4maps_react_choose_point.js",)
 
-        css = {"all": ["a4maps_choose_point.css"]}
+        css = {"all": ["a4maps_react_choose_point.css"]}
 
     def render(self, name, value, attrs, renderer=None):
-        if not finders.find("a4maps_choose_point.js"):
+        if not finders.find("a4maps_react_choose_point.js"):
             raise ImproperlyConfigured(
-                "Configure your frontend build tool to generate a4maps_choose_point.js."
+                "Configure your frontend build tool to generate a4maps_react_choose_point.js."
             )
 
         context = {

--- a/tests/maps_react/test_templatetags.py
+++ b/tests/maps_react/test_templatetags.py
@@ -22,7 +22,7 @@ def test_react_maps_without_point(rf, area_settings):
         }
     }
     expected = format_html(
-        '<div data-a4-widget="choose-point" data-attributes="{attributes}"></div>',
+        '<div data-a4-widget="react-choose-point" data-attributes="{attributes}"></div>',
         attributes=json.dumps(attrs),
     )
 
@@ -50,7 +50,7 @@ def test_react_maps_with_point(rf, area_settings):
         }
     }
     expected = format_html(
-        '<div data-a4-widget="choose-point" data-attributes="{attributes}"></div>',
+        '<div data-a4-widget="react-choose-point" data-attributes="{attributes}"></div>',
         attributes=json.dumps(attrs),
     )
 

--- a/tests/maps_react/test_widget.py
+++ b/tests/maps_react/test_widget.py
@@ -39,7 +39,7 @@ def test_choose_point_widget(area_settings):
         expected = format_html(
             """
 
-<div data-a4-widget="choose-point" data-attributes="{attributes}"></div>
+<div data-a4-widget="react-choose-point" data-attributes="{attributes}"></div>
 <input id="id_test_filter" type="hidden" name="test_filter" value="test_val1">
 """,
             attributes=json.dumps(attrs),


### PR DESCRIPTION
fixes map namespace clash with react_maps

mb PR: https://github.com/liqd/a4-meinberlin/pull/6003

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
