### PR TITLE
comments: move report and share into dropdown

### DIFF
--- a/adhocracy4/comments_async/static/comments_async/__tests__/__snapshots__/comment.jest.jsx.snap
+++ b/adhocracy4/comments_async/static/comments_async/__tests__/__snapshots__/comment.jest.jsx.snap
@@ -43,7 +43,42 @@ exports[`Comment Component renders comment with creator and comment text 1`] = `
               </div>
               <div
                 class="col-1 ms-auto a4-comments__dropdown-container"
-              />
+              >
+                <div
+                  class="dropdown a4-comments__dropdown"
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    class="dropdown-toggle btn btn--link"
+                    data-bs-toggle="dropdown"
+                    type="button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="fas fa-ellipsis-h"
+                    />
+                  </button>
+                  <ul
+                    class="dropdown-menu dropdown-menu-end"
+                  >
+                    <li
+                      class="dropdown-item a4-comments__dropdown__url"
+                    >
+                      <button
+                        class="a4-modal__toggle btn-link link"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="fas fa-share"
+                        />
+                         
+                        Share
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+              </div>
               <div
                 class="col-12"
               >
@@ -139,16 +174,6 @@ exports[`Comment Component renders comment with creator and comment text 1`] = `
                        
                       Reply
                     </a>
-                  </button>
-                  <button
-                    class="a4-modal__toggle btn-link link"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="fas fa-share"
-                    />
-                     
-                    Share
                   </button>
                 </div>
               </div>
@@ -247,7 +272,42 @@ exports[`Comment Component renders comment with creator and comment text 1`] = `
             </div>
             <div
               class="col-1 ms-auto a4-comments__dropdown-container"
-            />
+            >
+              <div
+                class="dropdown a4-comments__dropdown"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  class="dropdown-toggle btn btn--link"
+                  data-bs-toggle="dropdown"
+                  type="button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="fas fa-ellipsis-h"
+                  />
+                </button>
+                <ul
+                  class="dropdown-menu dropdown-menu-end"
+                >
+                  <li
+                    class="dropdown-item a4-comments__dropdown__url"
+                  >
+                    <button
+                      class="a4-modal__toggle btn-link link"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="fas fa-share"
+                      />
+                       
+                      Share
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </div>
             <div
               class="col-12"
             >
@@ -343,16 +403,6 @@ exports[`Comment Component renders comment with creator and comment text 1`] = `
                      
                     Reply
                   </a>
-                </button>
-                <button
-                  class="a4-modal__toggle btn-link link"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="fas fa-share"
-                  />
-                   
-                  Share
                 </button>
               </div>
             </div>
@@ -463,7 +513,42 @@ exports[`Comment Component renders comment with moderator badge 1`] = `
               </div>
               <div
                 class="col-1 ms-auto a4-comments__dropdown-container"
-              />
+              >
+                <div
+                  class="dropdown a4-comments__dropdown"
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    class="dropdown-toggle btn btn--link"
+                    data-bs-toggle="dropdown"
+                    type="button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="fas fa-ellipsis-h"
+                    />
+                  </button>
+                  <ul
+                    class="dropdown-menu dropdown-menu-end"
+                  >
+                    <li
+                      class="dropdown-item a4-comments__dropdown__url"
+                    >
+                      <button
+                        class="a4-modal__toggle btn-link link"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="fas fa-share"
+                        />
+                         
+                        Share
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+              </div>
               <div
                 class="col-12"
               >
@@ -559,16 +644,6 @@ exports[`Comment Component renders comment with moderator badge 1`] = `
                        
                       Reply
                     </a>
-                  </button>
-                  <button
-                    class="a4-modal__toggle btn-link link"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="fas fa-share"
-                    />
-                     
-                    Share
                   </button>
                 </div>
               </div>
@@ -672,7 +747,42 @@ exports[`Comment Component renders comment with moderator badge 1`] = `
             </div>
             <div
               class="col-1 ms-auto a4-comments__dropdown-container"
-            />
+            >
+              <div
+                class="dropdown a4-comments__dropdown"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  class="dropdown-toggle btn btn--link"
+                  data-bs-toggle="dropdown"
+                  type="button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="fas fa-ellipsis-h"
+                  />
+                </button>
+                <ul
+                  class="dropdown-menu dropdown-menu-end"
+                >
+                  <li
+                    class="dropdown-item a4-comments__dropdown__url"
+                  >
+                    <button
+                      class="a4-modal__toggle btn-link link"
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="fas fa-share"
+                      />
+                       
+                      Share
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </div>
             <div
               class="col-12"
             >
@@ -768,16 +878,6 @@ exports[`Comment Component renders comment with moderator badge 1`] = `
                      
                     Reply
                   </a>
-                </button>
-                <button
-                  class="a4-modal__toggle btn-link link"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="fas fa-share"
-                  />
-                   
-                  Share
                 </button>
               </div>
             </div>

--- a/adhocracy4/comments_async/static/comments_async/comment.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment.jsx
@@ -338,13 +338,13 @@ export default class Comment extends React.Component {
               </div>
 
               <div className="col-1 ms-auto a4-comments__dropdown-container">
-                {!this.props.is_deleted && (this.props.has_changing_permission || this.props.has_deleting_permission) &&
+                {!this.props.is_deleted &&
                   <CommentManageDropdown
                     id={this.props.id}
                     handleToggleEdit={this.toggleEdit.bind(this)}
                     has_changing_permission={this.props.has_changing_permission}
                     has_deleting_permission={this.props.has_deleting_permission}
-                    isParentComment={this.displayCategories()}
+                    showReport={!this.props.is_deleted && this.props.authenticated_user_pk && !this.props.is_users_own_comment}
                     modals={modals}
                   />}
               </div>
@@ -397,10 +397,6 @@ export default class Comment extends React.Component {
                         <i className={this.state.showChildComments ? 'fa fa-minus' : 'far fa-comment'} aria-hidden="true" /> {getAnswerForm(this.state.showChildComments, this.props.child_comments.length)}
                       </a>
                     </button>}
-
-                  {!this.props.is_deleted && modals.urlModal}
-
-                  {!this.props.is_deleted && this.props.authenticated_user_pk && !this.props.is_users_own_comment && modals.reportModal}
                 </div>
               </div>
             </div>

--- a/adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx
+++ b/adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx
@@ -19,6 +19,14 @@ const CommentManageDropdown = (props) => {
         <i className="fas fa-ellipsis-h" aria-hidden="true" />
       </button>
       <ul className="dropdown-menu dropdown-menu-end">
+        <li className="dropdown-item a4-comments__dropdown__url">
+          {props.modals.urlModal}
+        </li>
+        {props.showReport && (
+          <li className="dropdown-item a4-comments__dropdown__report">
+            {props.modals.reportModal}
+          </li>
+        )}
         {props.has_changing_permission && (
           <li className="dropdown-item">
             <button type="button" onClick={props.handleToggleEdit}>


### PR DESCRIPTION
This moves the report and share button of comments into the dot-menu/dropdown.

For more information, see this discussion https://github.com/liqd/a4-meinberlin/issues/6279

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
