### PR TITLE
[ST-234] Polls:Export: Anonymous users are added to the Export 

### DIFF
--- a/changelog/ST-234.md
+++ b/changelog/ST-234.md
@@ -1,0 +1,2 @@
+## Poll Module
+The non registered users are added to the Vote export. Votes and additional answers are included.  


### PR DESCRIPTION
**Tasks**
- [x ] PR name contains story or task reference
- [ x] Tests 
- [ x] Changelog


I attach the xls file with both registered and anonymous users. anonymous users are visible through the uuid instead of counting number. 


[test_20250528T161058.xlsx](https://github.com/user-attachments/files/20504294/test_20250528T161058.xlsx)
