### PR TITLE
apps/dashboard: add identifier to module menu

### DIFF
--- a/adhocracy4/dashboard/__init__.py
+++ b/adhocracy4/dashboard/__init__.py
@@ -112,6 +112,7 @@ class ProjectDashboard:
                 project_menu.append(
                     {
                         "label": component.label,
+                        "identifier": component.identifier,
                         "is_active": is_active,
                         "url": url,
                         "is_complete": is_complete,

--- a/changelog/ST-845.md
+++ b/changelog/ST-845.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added identifier for dashboard project module menu so translation doesn't break conditional display of "Location"

--- a/tests/dashboard/test_project_dashboard.py
+++ b/tests/dashboard/test_project_dashboard.py
@@ -67,6 +67,7 @@ def test_menu(module, dashboard_test_component_factory):
     project_component = project_components[0]
     assert project_dashboard.get_project_menu(project_component) == [
         {
+            "identifier": project_component.identifier,
             "label": project_component.label,
             "is_active": True,
             "url": "pc1_url",
@@ -88,6 +89,7 @@ def test_menu(module, dashboard_test_component_factory):
     assert project_dashboard.get_menu(None, project_component) == {
         "project": [
             {
+                "identifier": project_component.identifier,
                 "label": project_component.label,
                 "is_active": True,
                 "url": "pc1_url",


### PR DESCRIPTION
Fixes issue in a+ where location / ort dashboard module shows up when switching to german language
https://github.com/liqd/adhocracy-plus/issues/2938 / https://app.asana.com/1/1175467295883992/project/1209245838104549/task/1210868049976111?focus=true

PR in a+: https://github.com/liqd/adhocracy-plus/pull/2966