### PR TITLE
[ST-1889] Remove phase start action for offline events notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 This project (not yet) adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Unreleased
+
+### Fixed
+
+- Offline events no longer trigger notification on phase start (only 72 hours before event)
 
 ## meinBerlin-v2604.1
 

--- a/adhocracy4/actions/management/commands/create_system_actions.py
+++ b/adhocracy4/actions/management/commands/create_system_actions.py
@@ -44,7 +44,6 @@ class Command(BaseCommand):
         In the projects this is used to notify users if a phase has started.
         """
         phase_ct = ContentType.objects.get_for_model(Phase)
-        print("locallllllll ------ ")
         phases = (
             Phase.objects.filter(module__is_draft=False)
             .filter(module__project__is_draft=False)

--- a/adhocracy4/actions/management/commands/create_system_actions.py
+++ b/adhocracy4/actions/management/commands/create_system_actions.py
@@ -48,6 +48,7 @@ class Command(BaseCommand):
         phases = (
             Phase.objects.filter(module__is_draft=False)
             .filter(module__project__is_draft=False)
+            .exclude(type__contains="offline-event")
             .start_last(hours=self.phase_started_hours)
         )
         for phase in phases:
@@ -92,7 +93,7 @@ class Command(BaseCommand):
         starting_soon = Phase.objects.filter(
             module__is_draft=False,
             module__project__is_draft=False,
-            type__contains="offline-event",  # Todo: confirm since this type is mB only, okay to leave here for a+ forks
+            type__contains="offline-event",
             start_date__gte=now,
             start_date__lte=now + timedelta(hours=offline_hours),
         )

--- a/adhocracy4/actions/management/commands/create_system_actions.py
+++ b/adhocracy4/actions/management/commands/create_system_actions.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         In the projects this is used to notify users if a phase has started.
         """
         phase_ct = ContentType.objects.get_for_model(Phase)
-
+        print("locallllllll ------ ")
         phases = (
             Phase.objects.filter(module__is_draft=False)
             .filter(module__project__is_draft=False)


### PR DESCRIPTION
**Tasks**
- [x] PR name contains story or task reference
- [x] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog

see https://github.com/liqd/a4-meinberlin/pull/6696