### PR TITLE
[ST-1940] emails/base: add get_from_email hook for custom sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project (not yet) adheres to [Semantic Versioning](https://semver.org/spec/
 
 ### Added
 
+- emails: add `get_from_email()` hook on `EmailBase` so projects can customize
+  the sender address without overriding `dispatch()`.
+
 ### Fixed
 
 ### Changed

--- a/adhocracy4/emails/base.py
+++ b/adhocracy4/emails/base.py
@@ -75,6 +75,11 @@ class EmailBase:
     def get_reply_to(self):
         return None
 
+    # Override in project email subclasses to customise the From header.
+    # Defaults to Django's DEFAULT_FROM_EMAIL setting (address only).
+    def get_from_email(self):
+        return settings.DEFAULT_FROM_EMAIL
+
     @classmethod
     def send(cls, obj, *args, **kwargs):
         content_type = ContentType.objects.get_for_model(model=obj.__class__)
@@ -133,7 +138,7 @@ class EmailBase:
             mail = EmailMultiAlternatives(
                 subject=subject_clean,
                 body=text,
-                from_email=settings.DEFAULT_FROM_EMAIL,
+                from_email=self.get_from_email(),
                 to=[to_address],
                 reply_to=self.get_reply_to(),
             )

--- a/docs/emails.md
+++ b/docs/emails.md
@@ -1,0 +1,37 @@
+# Emails
+
+adhocracy4 sends templated emails through `EmailBase` and its subclasses in
+`adhocracy4/emails/`. Celery delivers them asynchronously via
+`adhocracy4.emails.tasks.send_async`.
+
+## Customising the From header
+
+`EmailBase.dispatch()` uses `get_from_email()` when building each message. The
+default implementation returns Django's `DEFAULT_FROM_EMAIL` setting (configure
+this in your project's settings, e.g. production `local.py`).
+
+Subclass `Email` (or a project-specific base class) and override
+`get_from_email()` to set a display name or a different sender address — no need
+to copy `dispatch()`.
+
+Example:
+
+```python
+from email.utils import formataddr, parseaddr
+from django.conf import settings
+from adhocracy4.emails import Email
+
+
+class ProjectEmail(Email):
+    def get_from_email(self):
+        _, address = parseaddr(settings.DEFAULT_FROM_EMAIL)
+        return formataddr(("My platform", address))
+```
+
+Other hooks on `EmailBase` include `get_reply_to()`, `get_receivers()`, and
+`get_organisation()`.
+
+## Attachments
+
+Optional inline images (e.g. logo) are configured via the `A4_EMAIL_ATTACHMENTS`
+setting — see the changelog.

--- a/tests/emails/test_from_email.py
+++ b/tests/emails/test_from_email.py
@@ -1,0 +1,32 @@
+import pytest
+from django.conf import settings
+from django.core import mail
+
+from adhocracy4.emails.base import EmailBase
+from adhocracy4.emails.mixins import SyncEmailMixin
+from adhocracy4.reports.emails import ReportModeratorEmail
+from tests.reports.factories import ReportFactory
+
+
+def test_get_from_email_defaults_to_settings():
+    email = EmailBase()
+    assert email.get_from_email() == settings.DEFAULT_FROM_EMAIL
+
+
+class CustomFromEmail(SyncEmailMixin, EmailBase):
+    template_name = ReportModeratorEmail.template_name
+
+    def get_receivers(self):
+        return [self.kwargs["receiver"]]
+
+    def get_from_email(self):
+        return "Custom Sender <custom@example.com>"
+
+
+@pytest.mark.django_db
+def test_dispatch_uses_get_from_email(user):
+    report = ReportFactory()
+    CustomFromEmail.send(report, receiver=user.email)
+
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].from_email == "Custom Sender <custom@example.com>"


### PR DESCRIPTION
**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
